### PR TITLE
Build platform specific installers for windows, linux and mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# This workflow will build a Java project with Gradle, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Build project

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Execute build
-        run: ./gradlew build -Djava.awt.headless=true -Dtestfx.headless=true --no-daemon
+        run: ./gradlew build --no-daemon
       - name: Execute runtime
-        run: ./gradlew runtime -Djava.awt.headless=true -Dtestfx.headless=true --no-daemon
+        run: ./gradlew runtime --no-daemon
       - name: Execute jpackage
-        run: ./gradlew jpackage -Djava.awt.headless=true -Dtestfx.headless=true --no-daemon
+        run: ./gradlew jpackage --no-daemon
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,60 @@
+# understands how to build platform specific binaries that ship with the necessary java runtime
+name: Package Platform Specific Runtimes and Installer
+
+on:
+  push:
+    branches: [ "main", "feature/513-include-jre" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+      fail-fast: false
+    name: ${{ matrix.os }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '18'
+          distribution: 'zulu'
+          java-package: "jdk+fx"
+          cache: "gradle"
+      - name: Echo JAVA_HOME
+        run: echo $JAVA_HOME
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Execute build
+        run: ./gradlew --info --stacktrace build
+      - name: Execute runtime
+        run: ./gradlew --info --stacktrace runtime
+      - name: Execute jpackage
+        run: ./gradlew --info --stacktrace jpackage
+      - name: Upload DMG as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: hellofx-jdk${{ matrix.java }}-${{ matrix.os }}-dmg
+          path: build/jpackage/*.dmg
+      - name: Upload EXE as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: siard-suite-${{ matrix.os }}-exe
+          path: build/jpackage/*.exe
+      - name: Upload MSI as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: siard-suite-${{ matrix.os }}-msi
+          path: build/jpackage/*.msi
+      - name: Upload DEB as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: siard-suite-${{ matrix.os }}-deb
+          path: build/jpackage/*.deb
+      - name: Upload RPM as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: siard-suite-${{ matrix.os }}-rpm
+          path: build/jpackage/*.rpm

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,9 @@
-name: Gradle Build
+# understands how to build platform specific binaries that ship with the necessary java runtime
+name: Package Platform Specific Runtimes and Installer
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main", "feature/513-include-jre" ]
 
 jobs:
   build:
@@ -8,20 +11,22 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '18' ]
       fail-fast: false
     name: ${{ matrix.os }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
+          java-version: '18'
+          distribution: 'zulu'
+          java-package: "jdk+fx"
+          cache: "gradle"
       - name: Echo JAVA_HOME
         run: echo $JAVA_HOME
-      - name: Verify Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Execute build
         run: ./gradlew --info --stacktrace build
       - name: Execute runtime
@@ -31,25 +36,25 @@ jobs:
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-dmg
+          name: hellofx-jdk${{ matrix.java }}-${{ matrix.os }}-dmg
           path: build/jpackage/*.dmg
       - name: Upload EXE as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-exe
+          name: siard-suite-${{ matrix.os }}-exe
           path: build/jpackage/*.exe
       - name: Upload MSI as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-msi
+          name: siard-suite-${{ matrix.os }}-msi
           path: build/jpackage/*.msi
       - name: Upload DEB as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-deb
+          name: siard-suite-${{ matrix.os }}-deb
           path: build/jpackage/*.deb
       - name: Upload RPM as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-rpm
+          name: siard-suite-${{ matrix.os }}-rpm
           path: build/jpackage/*.rpm

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-latest, macOS-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         java: [ '18' ]
       fail-fast: false
     name: ${{ matrix.os }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,9 +1,6 @@
-# understands how to build platform specific binaries that ship with the necessary java runtime
-name: Package Platform Specific Runtimes and Installer
+name: Gradle Build
 
-on:
-  push:
-    branches: [ "main", "feature/513-include-jre" ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -11,22 +8,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        java: [ '18' ]
       fail-fast: false
     name: ${{ matrix.os }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v1
         with:
-          java-version: '18'
-          distribution: 'zulu'
-          java-package: "jdk+fx"
-          cache: "gradle"
+          java-version: ${{ matrix.java }}
       - name: Echo JAVA_HOME
         run: echo $JAVA_HOME
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+      - name: Verify Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
       - name: Execute build
         run: ./gradlew --info --stacktrace build
       - name: Execute runtime
@@ -36,25 +31,25 @@ jobs:
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: hellofx-jdk${{ matrix.java }}-${{ matrix.os }}-dmg
+          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-dmg
           path: build/jpackage/*.dmg
       - name: Upload EXE as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-${{ matrix.os }}-exe
+          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-exe
           path: build/jpackage/*.exe
       - name: Upload MSI as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-${{ matrix.os }}-msi
+          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-msi
           path: build/jpackage/*.msi
       - name: Upload DEB as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-${{ matrix.os }}-deb
+          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-deb
           path: build/jpackage/*.deb
       - name: Upload RPM as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-${{ matrix.os }}-rpm
+          name: siard-suite-jdk${{ matrix.java }}-${{ matrix.os }}-rpm
           path: build/jpackage/*.rpm

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        #os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest]
+        java: [ '18' ]
       fail-fast: false
     name: ${{ matrix.os }}
     steps:
@@ -19,7 +21,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '18'
+          java-version: ${{ matrix.java }}
           distribution: 'zulu'
           java-package: "jdk+fx"
           cache: "gradle"
@@ -28,33 +30,33 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Execute build
-        run: ./gradlew --info --stacktrace build
+        run: ./gradlew build -Djava.awt.headless=true -Dtestfx.headless=true --no-daemon
       - name: Execute runtime
-        run: ./gradlew --info --stacktrace runtime
+        run: ./gradlew runtime -Djava.awt.headless=true -Dtestfx.headless=true --no-daemon
       - name: Execute jpackage
-        run: ./gradlew --info --stacktrace jpackage
+        run: ./gradlew jpackage -Djava.awt.headless=true -Dtestfx.headless=true --no-daemon
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: hellofx-jdk${{ matrix.java }}-${{ matrix.os }}-dmg
+          name: siard-suite-jdk-${{ matrix.java }}-${{ matrix.os }}-dmg
           path: build/jpackage/*.dmg
       - name: Upload EXE as an artifact
         uses: actions/upload-artifact@v3
         with:
-          name: siard-suite-${{ matrix.os }}-exe
+          name: siard-suite-jdk-${{ matrix.java }}-${{ matrix.os }}-exe
           path: build/jpackage/*.exe
       - name: Upload MSI as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-${{ matrix.os }}-msi
+          name: siard-suite-jdk-${{ matrix.java }}-${{ matrix.os }}-msi
           path: build/jpackage/*.msi
       - name: Upload DEB as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-${{ matrix.os }}-deb
+          name: siard-suite-jdk-${{ matrix.java }}-${{ matrix.os }}-deb
           path: build/jpackage/*.deb
       - name: Upload RPM as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: siard-suite-${{ matrix.os }}-rpm
+          name: siard-suite-jdk-${{ matrix.java }}-${{ matrix.os }}-rpm
           path: build/jpackage/*.rpm

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ name: Package Platform Specific Runtimes and Installer
 
 on:
   push:
-    branches: [ "main", "feature/513-include-jre" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ To create a platform specific installer use:
 ./gradlew jpackage
 ```
 
+Hint: If you are working on ubuntu building the rpm installer may fail - in this case install the necessary packages on your system:
+
+```shell
+sudo apt install alien
+```

--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ Run tests and build the package
 ```
 
 the build task creates a distribution in `build/distributions` that contains an archive with the necessary executable scripts.
+
+You can also create platform specific images that include the necessary jre and provides a binary to start the application:
+
+```shell
+./gradlew jpackageImage
+```
+
+The image is available at `./build/jpackage/siard-suite`
+
+To create a platform specific installer use:
+
+```shell
+./gradlew jpackage
+```
+

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,6 @@ runtime {
         if (currentOs.windows) {
             installerOptions += ['--win-per-user-install', '--win-dir-chooser', '--win-menu', '--win-shortcut']
         } else if (currentOs.linux) {
-            installerType = "deb"
             installerOptions += ['--linux-package-name', 'siard-suite', '--linux-shortcut']
         } else if (currentOs.macOsX) {
             installerOptions += ['--mac-package-name', 'siard-suite']

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,6 @@ repositories {
     }
 }
 
-configurations {
-    resolvableImplementation.extendsFrom implementation
-}
-
-
 group = 'ch.admin.bar'
 version = '1.0-SNAPSHOT'
 description = 'SIARD Suite'

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ runtime {
     ]
 
     jpackage {
-        appVersion = '0.1'
+        appVersion = '1.0'
 
         def currentOs = org.gradle.internal.os.OperatingSystem.current()
         def imgType = currentOs.windows ? 'ico' : currentOs.macOsX ? 'icns' : 'png'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.13'
+    id 'org.beryx.runtime' version '1.12.7'
 }
 
 repositories {
@@ -15,7 +16,7 @@ group = 'ch.admin.bar'
 version = '1.0-SNAPSHOT'
 description = 'SIARD Suite'
 java.sourceCompatibility = JavaVersion.VERSION_18
-mainClassName = "ch.admin.bar.siardsuite.SiardApplication"
+mainClassName = "ch.admin.bar.siardsuite.Launcher"
 
 
 dependencies {
@@ -65,5 +66,44 @@ javafx {
 }
 
 application {
+    mainClass = mainClassName
     applicationDefaultJvmArgs = ['--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED', '--add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED', '--add-opens=javafx.graphics/com.sun.javafx.application=ALL-UNNAMED']
+}
+
+runtime {
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+
+    launcher {
+        noConsole = true
+    }
+
+    additive = true
+    modules = [
+        'java.logging',
+        'java.sql',
+        'java.management',
+        'java.naming'
+    ]
+
+    jpackage {
+        // Uncomment and adjust the following line if your runtime task is configured to generate images for multiple platforms
+        // targetPlatformName = "mac"
+
+        def currentOs = org.gradle.internal.os.OperatingSystem.current()
+        def imgType = currentOs.windows ? 'ico' : currentOs.macOsX ? 'icns' : 'png'
+        //imageOptions += ['--icon', "src/main/resources/hellofx.$imgType"]
+        imageOptions += ['--icon', "src/main/resources/ch/admin/bar/siardsuite/icons/archive.png"]
+
+        installerOptions += ['--resource-dir', "src/main/resources"]
+        installerOptions += ['--vendor', 'BUAR']
+
+        if (currentOs.windows) {
+            installerOptions += ['--win-per-user-install', '--win-dir-chooser', '--win-menu', '--win-shortcut']
+        } else if (currentOs.linux) {
+            installerType = "deb"
+            installerOptions += ['--linux-package-name', 'siard-suite', '--linux-shortcut']
+        } else if (currentOs.macOsX) {
+            installerOptions += ['--mac-package-name', 'siard-suite']
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,7 @@ runtime {
     ]
 
     jpackage {
-        // Uncomment and adjust the following line if your runtime task is configured to generate images for multiple platforms
-        // targetPlatformName = "mac"
+        appVersion = '0.1'
 
         def currentOs = org.gradle.internal.os.OperatingSystem.current()
         def imgType = currentOs.windows ? 'ico' : currentOs.macOsX ? 'icns' : 'png'
@@ -100,6 +99,7 @@ runtime {
         if (currentOs.windows) {
             installerOptions += ['--win-per-user-install', '--win-dir-chooser', '--win-menu', '--win-shortcut']
         } else if (currentOs.linux) {
+            installerType="deb"
             installerOptions += ['--linux-package-name', 'siard-suite', '--linux-shortcut']
         } else if (currentOs.macOsX) {
             installerOptions += ['--mac-package-name', 'siard-suite']

--- a/src/main/java/ch/admin/bar/siardsuite/Launcher.java
+++ b/src/main/java/ch/admin/bar/siardsuite/Launcher.java
@@ -1,0 +1,8 @@
+package ch.admin.bar.siardsuite;
+
+
+public class Launcher {
+    public static void main(String[] args) {
+        ch.admin.bar.siardsuite.SiardApplication.main(args);
+    }
+}

--- a/src/test/java/ch/admin/bar/siardsuite/component/StepperButtonBoxTest.java
+++ b/src/test/java/ch/admin/bar/siardsuite/component/StepperButtonBoxTest.java
@@ -1,5 +1,6 @@
 package ch.admin.bar.siardsuite.component;
 
+import org.junit.Before;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.framework.junit5.ApplicationExtension;
@@ -12,6 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(ApplicationExtension.class)
 public class StepperButtonBoxTest {
+
+    @Before
+    public void setUpHeadlessMode() {
+        System.setProperty("java.awt.headless", "true");
+        System.setProperty("testfx.headless", "true");
+    }
 
     @Test
     void shouldCreateDefaultButtonBox() {


### PR DESCRIPTION
A new github action workflow builds platform specific installers for windows, mac and linux.

This is done with the badass-runtime-plugin for gradle that also includes the java runtime - users do not need to install anything except the application.

Additional work must be done later:
- Add application icons for all platforms
- check if we can sign the application for windows users
- ...