### PR TITLE
SIARD-516: Outline for Lazy Loading Records

### DIFF
--- a/src/main/java/ch/admin/bar/siardsuite/model/database/DatabaseTable.java
+++ b/src/main/java/ch/admin/bar/siardsuite/model/database/DatabaseTable.java
@@ -42,21 +42,19 @@ public class DatabaseTable extends DatabaseObject {
             columns.add(new DatabaseColumn(archive, schema, this, table.getMetaTable().getMetaColumn(i)));
         }
         numberOfColumns = String.valueOf(columns.size());
-        String n = "";
         if (!onlyMetaData) {
             try {
                 int i = 0;
                 final RecordDispenser recordDispenser = table.openRecords();
-                while (i < table.getMetaTable().getRows()) {
+                while (i < table.getMetaTable().getRows() && i < 50) {
                     rows.add(new DatabaseRow(archive, schema, this, recordDispenser.get()));
                     i++;
                 }
-                n = String.valueOf(rows.size());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
-        numberOfRows = n;
+        numberOfRows = String.valueOf(table.getMetaTable().getRows());
     }
 
     protected void shareProperties(SiardArchiveVisitor visitor) {

--- a/src/main/java/ch/admin/bar/siardsuite/presenter/PreviewPresenter.java
+++ b/src/main/java/ch/admin/bar/siardsuite/presenter/PreviewPresenter.java
@@ -35,7 +35,7 @@ public class PreviewPresenter extends StepperPresenter implements SiardArchiveVi
   private String tableName = "";
   private List<DatabaseColumn> columns = new ArrayList<>();
   private String columnName = "";
-  private List<DatabaseRow> rows = new ArrayList<>();
+  private String numberOfRows = "";
   protected final Node db = new ImageView(new Image(String.valueOf(SiardApplication.class.getResource("icons/server.png")), 16.0, 16.0, true, false));
   @FXML
   protected TreeView<TreeAttributeWrapper> treeView;
@@ -106,7 +106,7 @@ public class PreviewPresenter extends StepperPresenter implements SiardArchiveVi
 
         if (!onlyMetaData) {
           rowsItem = new TreeItem<>();
-          rowsItem.valueProperty().bind(I18n.createTreeAtributeWrapperBinding("archive.tree.view.node.rows", TreeContentView.ROWS, table, rows.size()));
+          rowsItem.valueProperty().bind(I18n.createTreeAtributeWrapperBinding("archive.tree.view.node.rows", TreeContentView.ROWS, table, numberOfRows));
 
           tableItem.getChildren().add(rowsItem);
         }
@@ -176,7 +176,7 @@ public class PreviewPresenter extends StepperPresenter implements SiardArchiveVi
   public void visit(String tableName, String numberOfRows, List<DatabaseColumn> columns, List<DatabaseRow> rows) {
     this.tableName = tableName;
     this.columns = columns;
-    this.rows = rows;
+    this.numberOfRows = numberOfRows;
   }
 
   @Override

--- a/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_de.properties
+++ b/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_de.properties
@@ -113,10 +113,10 @@ archiveMetadata.view.tooltip=Falls zukünftige Nutzer/innen Fragen zur Archivdate
 können Sie durch diese Angaben erreicht werden.
 
 # Archive Tree View
-archive.tree.view.node.schemas = Schemas (%d)
-archive.tree.view.node.tables = Tabellen (%d)
-archive.tree.view.node.columns = Spalten (%d)
-archive.tree.view.node.rows = Datensätze (%d)
+archive.tree.view.node.schemas = Schemas (%s)
+archive.tree.view.node.tables = Tabellen (%s)
+archive.tree.view.node.columns = Spalten (%s)
+archive.tree.view.node.rows = Datensätze (%s)
 
 # TableContainer
 tableContainer.title.siardFile=SIARD-Datei

--- a/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_en.properties
+++ b/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_en.properties
@@ -118,10 +118,10 @@ archiveDownload.view.title.success=Success
 archiveDownload.view.title.failed=Download failed
 
 # Preview View - Tree
-archive.tree.view.node.schemas = Schemas (%d)
-archive.tree.view.node.tables = Tables (%d)
-archive.tree.view.node.columns = Columns (%d)
-archive.tree.view.node.rows = Records (%d)
+archive.tree.view.node.schemas = Schemas (%s)
+archive.tree.view.node.tables = Tables (%s)
+archive.tree.view.node.columns = Columns (%s)
+archive.tree.view.node.rows = Records (%s)
 
 # TableContainer
 tableContainer.title.siardFile=SIARD file

--- a/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_fr.properties
+++ b/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_fr.properties
@@ -110,10 +110,10 @@ archiveMetadata.view.tooltip=Si de futurs utilisateurs ont des questions sur le 
 vous êtes joignable grâce à ces informations.
 
 # Archive Tree View
-archive.tree.view.node.schemas = Schémas (%d)
-archive.tree.view.node.tables = Tableaux (%d)
-archive.tree.view.node.columns = Colonnes (%d)
-archive.tree.view.node.rows = Données (%d)
+archive.tree.view.node.schemas = Schémas (%s)
+archive.tree.view.node.tables = Tableaux (%s)
+archive.tree.view.node.columns = Colonnes (%s)
+archive.tree.view.node.rows = Données (%s)
 
 # TableContainer
 tableContainer.title.siardFile=Fichier SIARD

--- a/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_it.properties
+++ b/src/main/resources/ch/admin/bar/siardsuite/i18n/messages_it.properties
@@ -112,10 +112,10 @@ archiveMetadata.view.tooltip=Se futuri utenti hanno domande sul file di archivio
 puoi essere raggiunto attraverso queste informazioni.
 
 # Archive Tree View
-archive.tree.view.node.schemas = Schemi (%d)
-archive.tree.view.node.tables = Tabelle (%d)
-archive.tree.view.node.columns = Colonne (%d)
-archive.tree.view.node.rows = Dati (%d)
+archive.tree.view.node.schemas = Schemi (%s)
+archive.tree.view.node.tables = Tabelle (%s)
+archive.tree.view.node.columns = Colonne (%s)
+archive.tree.view.node.rows = Dati (%s)
 
 # TableContainer
 tableContainer.title.siardFile=SIARD-Datei


### PR DESCRIPTION
First draft: Scroll to the bottom of a large table by using your trackpad and the records will get loaded lazily.

I initially tried to rely on some features of the table view -- which unfortunately didn't work because our view hierarchy (stage, scene, etc.) didn't allow me to get useful information from the table skin (which cells are visible, etc.). Therefore, I came up with my own solution for implementing lazy loading for our purposes. Lucky, my solution relies on a relatively small code base.