### PR TITLE
Switch to Java 17 for Build and Development Environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
       - name: Set TAG-Env
         run: echo "NAME_TAG=SIARD-Suite-${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set up JDK 18
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '18'
+          java-version: '17'
           distribution: 'zulu'
           java-package: "jdk+fx"
           cache: "gradle"

--- a/.github/workflows/deliverables.yml
+++ b/.github/workflows/deliverables.yml
@@ -3,8 +3,6 @@ name: Create standalone deliverables for SIARD (installers and distributions wit
 
 on:
   push:
-    push:
-      branches: [ "feature/java-17-development-env" ]
     tags:
       - v*.**
 

--- a/.github/workflows/deliverables.yml
+++ b/.github/workflows/deliverables.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Execute build runtimeZip jpackage
-        run: ./gradlew build runtimeZip jpackage -x test --no-daemon
+        run: ./gradlew build runtimeZip jpackage --no-daemon
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/deliverables.yml
+++ b/.github/workflows/deliverables.yml
@@ -15,10 +15,10 @@ jobs:
           fetch-depth: 0
       - name: Set TAG-Env
         run: echo "NAME_TAG=SIARD-Suite-${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set up JDK 18
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '18'
+          java-version: '17'
           distribution: 'zulu'
           java-package: "jdk+fx"
           cache: "gradle"
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '18' ]
+        java: [ '17' ]
       fail-fast: false
     name: ${{ matrix.os }}
     steps:

--- a/.github/workflows/deliverables.yml
+++ b/.github/workflows/deliverables.yml
@@ -3,6 +3,8 @@ name: Create standalone deliverables for SIARD (installers and distributions wit
 
 on:
   push:
+    push:
+      branches: [ "feature/java-17-development-env" ]
     tags:
       - v*.**
 

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,7 +10,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="zulu-18-fx" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="jdk+fx-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/target" />
   </component>
 </project>

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-java zulu-javafx-18.32.13
+java zulu-javafx-17.42.19
 maven 3.6.3
 gradle 7.3.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# siard-suite
+# SIARD Suite 2.2.x
 
-## for developers
+The SIARD (Software-Independent Archival of Relational Databases) standard defines a format for the long-term archival
+of relational database contents. To facilitate this process, the "Siard Suite" application offers a user-friendly
+graphical interface for archiving, restoring, searching, and exporting SIARD archives. With its intuitive design Siard
+Suite makes it easy to preserve valuable data from relational databases in a way that ensures its longevity and
+accessibility.
+
+## Development
+
+### Prerequisites
+
+Java 17 with Java FX - you can get it from here: https://www.azul.com/downloads/?version=java-17-lts&package=jdk-fx#zulu
+
+For [asdf](https://asdf-vm.com/) users:
+
+```shell
+asdf install
+```
+
+### CLI
 
 Run the application from the command line:
 
@@ -8,21 +26,26 @@ Run the application from the command line:
 ./gradlew run
 ```
 
+### Build application artifacts
+
 Run tests and build the package
 
 ```shell
 ./gradlew build
 ```
 
-the build task creates a distribution in `build/distributions` that contains an archive with the necessary executable scripts.
+the build task creates a distribution in `build/distributions` that contains an archive with the necessary executable
+scripts.
 
-You can also create platform specific images that include the necessary jre and provides a binary to start the application:
+You can also create platform specific runtimes for the application:
 
 ```shell
 ./gradlew jpackageImage
 ```
 
-The image is available at `./build/jpackage/siard-suite`
+_NOTE:_ You can only create images for the OS you are running the task on.
+
+The image is then available at `./build/jpackage/siard-suite`
 
 To create a platform specific installer use:
 
@@ -30,13 +53,14 @@ To create a platform specific installer use:
 ./gradlew jpackage
 ```
 
-Hint: If you are working on ubuntu building the rpm installer may fail - in this case install the necessary packages on your system:
+Hint: If you are working on ubuntu building the rpm installer may fail - in this case install the necessary packages on
+your system:
 
 ```shell
 sudo apt install alien
 ```
 
-## versioning, tags and releases
+## Versioning, tags and releases
 
 Versions and tags are managed with the Axion Release Plugin for Gradle (https://github.com/allegro/axion-release-plugin)
 
@@ -48,21 +72,24 @@ Short overview:
 ./gradlew release        # creates a new release adds a tag and pushes it to remote.
 ```
 
-Run the release task to create a new patch version and push it to remote. The GitHub Actions will create the deliverables.
+Run the release task to create a new patch version and push it to remote. The GitHub Actions will create the
+deliverables.
 
-__NOTE: the official GitHub Release has be created manually by BUAR!__
+__NOTE: the official GitHub Release has to be created manually by BUAR!__
 
-While the versioning scheme looks like it's semver it is actually not! The major and minor version represent the supported SIARD Format version (currently 2.2)
+While the versioning scheme looks like it's semver it is actually not! The major and minor version represent the
+supported SIARD Format version (currently 2.2)
 
-## documentation
+## Documentation
 
-Siard-Suite documentation is made with  [Asciidoc]( https://asciidoctor.org/).
+The documentation is made with  [Asciidoc]( https://asciidoctor.org/).
 
-To build the docs locally use: 
+Create the documentation PDF:
 
 ```shell
 ./gradlew asciidoctorPdf
 ```
 
-To provide the documentation with the app, the rendering of the documentation is included in the build step of the app.
+As part of the build process, the documentation is rendered and then bundled with the application artefact.
+
 


### PR DESCRIPTION
The application itself has to run with a Java8 FX environment. But in order to build platform specific runtimes we need a Jdk 9+ 

Initial development started with java 18 - but this version is no longer supported. Downgrading to the latest LTS version makes sense in this context.
With this pull request the project artefacts are now built with Java 17 (github action) and the intellij project configuration defines a jdk named `jdk+fx-17`.

Small changes to the docs should improve the experience for new developers.

