### PR TITLE
Skip the DB-type selection when reusing a previous connection.

### DIFF
--- a/src/main/java/ch/admin/bar/siardsuite/presenter/StepperPresenter.java
+++ b/src/main/java/ch/admin/bar/siardsuite/presenter/StepperPresenter.java
@@ -42,6 +42,11 @@ public abstract class StepperPresenter extends Presenter implements StepperDepen
 
         stepper.getStepperToggles().addAll(stepperToggles);
         stepper.setSkin(new CustomStepperSkin(stepper, stage));
+
+        if (stepper.getCurrentIndex() == -1) {
+            stepper.next();
+        }
+
         if (recentConnection) {
             stepper.getStepperToggles().get(0).setState(StepperToggleState.COMPLETED);
             stepper.updateProgress();


### PR DESCRIPTION
The lazy loading of Stepper-Views led to an unintended side effect: the DB-type selection was no longer skipped when reusing a connection.