### PR TITLE
Bugfix/loading issue in lazy loading table

### DIFF
--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/JumpingScrollingPositionIssueConcealer.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/JumpingScrollingPositionIssueConcealer.java
@@ -1,7 +1,6 @@
 package ch.admin.bar.siardsuite.component.rendering;
 
 import ch.admin.bar.siardsuite.component.rendering.utils.LoadingBatchManager;
-import ch.admin.bar.siardsuite.util.OptionalHelper;
 import javafx.application.Platform;
 import javafx.scene.control.ScrollBar;
 import javafx.scene.control.TableView;
@@ -13,26 +12,38 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * This class addresses an issue in JavaFX 8 related to the table view component: The scrolling position unexpectedly jumps
+ * when new items are added. This occurs only when the scrolling bar is close to its lowest position,
+ * which can be triggered if the scrolling position is set to the lowest position by dragging it with the mouse cursor.
+ * <p>
+ * Reference:
+ * <a href="https://stackoverflow.com/questions/32512654/javafx-8-stop-tableview-jumping-on-setall-call">
+ * Similar issue description, but with no working solution
+ * </a>
+ * <p>
+ * This issue is resolved in later releases of JavaFX (tested with JavaFX 17).
+ * <p>
+ * This class helps conceal the problematic behavior. To use it, call the {@link #concealIssue()} method
+ * every time the value of a table row is changed. The class then:
+ * - Checks if the scrolling bar is in an illegal state (not all data is loaded but the bar is at its lowest position).
+ * - If so, sets the scrolling position to a valid index (this happens in a separate thread on a scheduled basis. Otherwise,
+ * strange NullPointerExceptions are thrown by JavaFX).
+ * <p>
+ * TODO: Remove this workaround after upgrading the Java version. Thank you!
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class JumpingScrollingPositionIssueConcealer {
 
     private static final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(1);
 
-    private final AtomicBoolean scheduled = new AtomicBoolean(false);
-
     private final LoadingBatchManager loadingBatchManager;
     private final TableView<?> tableView;
 
     public void concealIssue() {
         if (!isScrollBarInIllegalState()) {
-            return;
-        }
-
-        if (scheduled.getAndSet(true)) {
-            // already a scheduled fix attempt -> do nothing
             return;
         }
 
@@ -58,13 +69,9 @@ public class JumpingScrollingPositionIssueConcealer {
         val lastLoadingIndex = loadingBatchManager.getLastLoadingIndex();
         Platform.runLater(
                 () -> {
-                    try {
-                        tableView.scrollTo((int) lastLoadingIndex);
-                        tableView.refresh();
-                        log.info("Scrolling position set to index {} because of trying to resolve illegal state.", lastLoadingIndex);
-                    } finally {
-                        scheduled.set(false);
-                    }
+                    tableView.scrollTo((int) lastLoadingIndex);
+                    tableView.refresh();
+                    log.info("Scrolling position set to index {} because of trying to resolve illegal state.", lastLoadingIndex);
                 }
         );
     }

--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/JumpingScrollingPositionIssueConcealer.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/JumpingScrollingPositionIssueConcealer.java
@@ -1,0 +1,71 @@
+package ch.admin.bar.siardsuite.component.rendering;
+
+import ch.admin.bar.siardsuite.component.rendering.utils.LoadingBatchManager;
+import ch.admin.bar.siardsuite.util.OptionalHelper;
+import javafx.application.Platform;
+import javafx.scene.control.ScrollBar;
+import javafx.scene.control.TableView;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JumpingScrollingPositionIssueConcealer {
+
+    private static final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(1);
+
+    private final AtomicBoolean scheduled = new AtomicBoolean(false);
+
+    private final LoadingBatchManager loadingBatchManager;
+    private final TableView<?> tableView;
+
+    public void concealIssue() {
+        if (!isScrollBarInIllegalState()) {
+            return;
+        }
+
+        if (scheduled.getAndSet(true)) {
+            // already a scheduled fix attempt -> do nothing
+            return;
+        }
+
+        SCHEDULER.schedule(
+                this::fixScrollPosition,
+                200,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    private boolean isScrollBarInIllegalState() {
+        return Optional.ofNullable((ScrollBar) tableView.lookup(".scroll-bar:vertical"))
+                .map(scrollBar -> {
+                    val value = scrollBar.getValue();
+                    val max = scrollBar.getMax();
+
+                    return value == max && !loadingBatchManager.loadedAll();
+                })
+                .orElse(false);
+    }
+
+    private void fixScrollPosition() {
+        val lastLoadingIndex = loadingBatchManager.getLastLoadingIndex();
+        Platform.runLater(
+                () -> {
+                    try {
+                        tableView.scrollTo((int) lastLoadingIndex);
+                        tableView.refresh();
+                        log.info("Scrolling position set to index {} because of trying to resolve illegal state.", lastLoadingIndex);
+                    } finally {
+                        scheduled.set(false);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/LazyLoadingTableRenderer.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/LazyLoadingTableRenderer.java
@@ -42,6 +42,8 @@ public class LazyLoadingTableRenderer<T, I> {
         val loadingBatchManager = new LoadingBatchManager<>(lazyLoadingDataSource);
         val tableView = new TableView<>(loadingBatchManager.getObservableList());
 
+        val issueConcealer = new JumpingScrollingPositionIssueConcealer(loadingBatchManager, tableView);
+
         tableView.getColumns().addAll(
                 renderableTable.getProperties().stream()
                         .map(this::column)
@@ -54,6 +56,8 @@ public class LazyLoadingTableRenderer<T, I> {
                 if (newValue != null) {
                     val index = lazyLoadingDataSource.findIndexOf(newValue);
                     loadingBatchManager.loadDataIfNecessary(index);
+
+                    issueConcealer.concealIssue();
                 }
             });
 

--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/model/LazyLoadingDataSource.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/model/LazyLoadingDataSource.java
@@ -6,4 +6,6 @@ public interface LazyLoadingDataSource<T> {
     List<T> load(int startIndex, int nrOfItems);
 
     long findIndexOf(T item);
+
+    long getNumberOfItems();
 }

--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatch.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatch.java
@@ -11,10 +11,6 @@ public class LoadingBatch {
     long nrOfElements;
     long batchNr;
 
-    public long calculateDistance(final LoadingBatch other) {
-        return other.batchNr - this.batchNr;
-    }
-
     public static LoadingBatch createMatchingLoadingBatch(long index) {
         val batchIndex = index % BATCH_SIZE;
         val startIndex = (index - batchIndex);

--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatch.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatch.java
@@ -5,7 +5,7 @@ import lombok.val;
 
 @Value
 public class LoadingBatch {
-    public static final int BATCH_SIZE = 50;
+    public static final int BATCH_SIZE = 100;
 
     long startIndex;
     long nrOfElements;

--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatchManager.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatchManager.java
@@ -50,4 +50,26 @@ public class LoadingBatchManager<T> {
 
         observableList.addAll(data);
     }
+
+    public boolean loadedAll() {
+        val currentlyLoaded = loadedBatches.stream()
+                .mapToLong(LoadingBatch::getNrOfElements)
+                .sum();
+
+        return currentlyLoaded >= dataSource.getNumberOfItems();
+    }
+
+    public long getLastLoadingIndex() {
+        val latestBatch = loadedBatches.stream()
+                .reduce((loadingBatch, loadingBatch2) -> {
+                    if (loadingBatch.getBatchNr() > loadingBatch2.getBatchNr()) {
+                        return loadingBatch;
+                    }
+                    return loadingBatch2;
+                });
+
+        return latestBatch
+                .map(batch -> batch.getStartIndex() + batch.getNrOfElements() - LOADING_DISTANCE)
+                .orElse(0L);
+    }
 }

--- a/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatchManager.java
+++ b/src/main/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatchManager.java
@@ -14,6 +14,8 @@ import java.util.Set;
 @Slf4j
 public class LoadingBatchManager<T> {
 
+    private static final int LOADING_DISTANCE = 50;
+
     @Getter
     private final ObservableList<T> observableList = FXCollections.observableArrayList();
     private final Set<LoadingBatch> loadedBatches = new HashSet<>();
@@ -26,15 +28,16 @@ public class LoadingBatchManager<T> {
     }
 
     public void loadDataIfNecessary(final long index) {
-        val matchingBatch = LoadingBatch.createMatchingLoadingBatch(index + 2);
+        val thresholdIndex = index + LOADING_DISTANCE;
+        val matchingBatch = LoadingBatch.createMatchingLoadingBatch(thresholdIndex);
 
         if (loadedBatches.contains(matchingBatch)) {
             // batch already loaded
             return;
         }
 
-        log.info("Data for index {} is not yet available, loading batch {} with start index {} (and length {})",
-                 index,
+        log.info("Data for threshold-index {} is not yet available, loading batch {} with start index {} (and length {})",
+                 thresholdIndex,
                  matchingBatch.getBatchNr(),
                  matchingBatch.getStartIndex(),
                  matchingBatch.getNrOfElements());

--- a/src/main/java/ch/admin/bar/siardsuite/presenter/archive/browser/forms/RowsOverviewForm.java
+++ b/src/main/java/ch/admin/bar/siardsuite/presenter/archive/browser/forms/RowsOverviewForm.java
@@ -144,6 +144,11 @@ public class RowsOverviewForm {
         public long findIndexOf(RecordWrapper item) {
             return item.getRecord().getRecord();
         }
+
+        @Override
+        public long getNumberOfItems() {
+            return table.getMetaTable().getRows();
+        }
     }
 
 

--- a/src/test/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatchTest.java
+++ b/src/test/java/ch/admin/bar/siardsuite/component/rendering/utils/LoadingBatchTest.java
@@ -5,56 +5,16 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class LoadingBatchTest {
-
-    @Test
-    public void calculateDistance_indexInOneOfThePreviousBatches_expectNegativeDistance() {
-        // given
-        val batch = LoadingBatch.createMatchingLoadingBatch(218);
-
-        // when
-        val batchDistance = batch.calculateDistance(LoadingBatch.createMatchingLoadingBatch(49));
-
-
-        // then
-        Assertions.assertThat(batchDistance).isEqualTo(-4);
-    }
-
-    @Test
-    public void calculateDistance_indexInSameBatch_expectNoDistance() {
-        // given
-        val batch = LoadingBatch.createMatchingLoadingBatch(0);
-
-        // when
-        val batchDistance = batch.calculateDistance(LoadingBatch.createMatchingLoadingBatch(49));
-
-
-        // then
-        Assertions.assertThat(batchDistance).isEqualTo(0);
-    }
-
-    @Test
-    public void calculateDistance_indexInOneOfTheNextBatches_expectPositiveDistance() {
-        // given
-        val batch = LoadingBatch.createMatchingLoadingBatch(0);
-
-        // when
-        val batchDistance = batch.calculateDistance(LoadingBatch.createMatchingLoadingBatch(249));
-
-
-        // then
-        Assertions.assertThat(batchDistance).isEqualTo(4);
-    }
-
     @Test
     public void createMatchingBatch_withIndexInsideFirstBatch_expectFirstBatch() {
         // given
 
         // when
-        val batch = LoadingBatch.createMatchingLoadingBatch(49);
+        val batch = LoadingBatch.createMatchingLoadingBatch(LoadingBatch.BATCH_SIZE - 1);
 
         // then
         Assertions.assertThat(batch.getStartIndex()).isEqualTo(0);
-        Assertions.assertThat(batch.getNrOfElements()).isEqualTo(50);
+        Assertions.assertThat(batch.getNrOfElements()).isEqualTo(LoadingBatch.BATCH_SIZE);
         Assertions.assertThat(batch.getBatchNr()).isEqualTo(0);
     }
 
@@ -63,12 +23,12 @@ class LoadingBatchTest {
         // given
 
         // when
-        val batch = LoadingBatch.createMatchingLoadingBatch(123);
+        val batch = LoadingBatch.createMatchingLoadingBatch(LoadingBatch.BATCH_SIZE + 23);
 
         // then
-        Assertions.assertThat(batch.getStartIndex()).isEqualTo(100);
-        Assertions.assertThat(batch.getNrOfElements()).isEqualTo(50);
-        Assertions.assertThat(batch.getBatchNr()).isEqualTo(2);
+        Assertions.assertThat(batch.getStartIndex()).isEqualTo(LoadingBatch.BATCH_SIZE);
+        Assertions.assertThat(batch.getNrOfElements()).isEqualTo(LoadingBatch.BATCH_SIZE);
+        Assertions.assertThat(batch.getBatchNr()).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
This PR addresses the issue where it was not possible to scroll to items beyond the 100th item (this problem surfaced while testing the fix for issue #61). The underlying problem was an unusual behavior of scrolling in the table view, which has been fixed in later Java FX versions. For detailed information, please refer to the JavaDoc in the JumpingScrollingPositionIssueConcealer.class.

Although this PR conceals the issue to some extent, it does not provide a definitive solution. Better approaches:
- Upgrading the Java version being used.
- Modifying the lazy-loading behavior of the siard-suite: Implementing pagination for large tables. With pagination, data doesn't need to be reloaded on-the-fly, and the scrolling-position bug will never occur. Pagination also improves performance and user experience. 
For instance, navigating to the last entry in a DB table: with the current solution, a user needs to scroll until the last entry is loaded. The entire table is loaded in-memory, which can lead to OutOfMemoryExceptions. With pagination, only the data of the current page is loaded, and the user only needs to scroll through that page to reach the last entry.