### PR TITLE
JdbcOrace Issue #4 - Missing Module for JDK 9+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,10 @@ tasks.withType(JavaCompile) {
 }
 
 tasks.withType(JavaExec) {
-    jvmArgs("--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED", "--add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED", "--add-opens=javafx.graphics/com.sun.javafx.application=ALL-UNNAMED", "--add-opens=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED")
+    jvmArgs("--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED",
+            "--add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED",
+            "--add-opens=javafx.graphics/com.sun.javafx.application=ALL-UNNAMED",
+            "--add-opens=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED")
 }
 
 runtime {

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,8 @@ runtime {
             'java.logging',
             'java.sql',
             'java.management',
-            'java.naming'
+            'java.naming',
+            'java.security.jgss',
     ]
 
     imageZip = file("$buildDir/image-zip/SIARD-Suite.${version}.zip")

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mssql:
     build:
@@ -10,3 +8,14 @@ services:
       SA_PASSWORD: Yukon900
     ports:
       - 1433:1433
+
+  oracle-xe:
+    image: gvenzl/oracle-xe:21-faststart
+    environment:
+      ORACLE_RANDOM_PASSWORD: yes
+      ORACLE_DATABASE: siard
+      APP_USER: siard
+      APP_USER_PASSWORD: siard
+    ports:
+      - 1521:1521
+

--- a/release-guide.md
+++ b/release-guide.md
@@ -69,6 +69,11 @@ In the application, please carry out the following steps to archive data sources
   * Username: sa
   * Password: Yukon900
 
+### Oracle
+   * Connection URL: jdbc:oracle:thin:@localhost:1521/siard
+   * Username: siard
+   * Password: siard
+
 ### MS Access
   * MS Access file: `/home/<username>/<your-directory>/siard-suite/docker/msaccess/Northwind.accdb`
 


### PR DESCRIPTION
The class `org.ietf.jgss.GSSException` is part of the jre itself, but was moved in jdk9. That's why it is not found on the classpath if a java 9+ is used to run the siard suite. This is the case for all bundled distributions of the application.

in order to make the class available on the classpath, I added to module to the build (in build.gradle)

I also added oracle 21 database service to `docker-compose.yaml` to simplify regression testing in the future.

resolves: https://github.com/sfa-siard/JdbcOracle/issues/4

