### PR TITLE
chore: define datatype mapping

### DIFF
--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/db2/issues/siardsuite163/Db2DataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/db2/issues/siardsuite163/Db2DataTypeMappingIT.java
@@ -49,7 +49,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("CHAR_COL"))
                 .build());
-        softly.assertThat(charCol.getType()).contains(Id.of("CHARACTER(1)"));
+        softly.assertThat(charCol.getType()).contains(Id.of("CHAR(1)"));
         softly.assertThat(charCol.getTypeOriginal()).contains(Id.of("CHAR"));
 
         // CHAR(n)
@@ -58,7 +58,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("CHAR_N_COL"))
                 .build());
-        softly.assertThat(charNCol.getType()).contains(Id.of("CHARACTER(10)"));
+        softly.assertThat(charNCol.getType()).contains(Id.of("CHAR(10)"));
         softly.assertThat(charNCol.getTypeOriginal()).contains(Id.of("CHAR"));
 
         // VARCHAR(n)
@@ -67,7 +67,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("VARCHAR_N_COL"))
                 .build());
-        softly.assertThat(varcharNCol.getType()).contains(Id.of("CHARACTER VARYING(100)"));
+        softly.assertThat(varcharNCol.getType()).contains(Id.of("VARCHAR(100)"));
         softly.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("VARCHAR"));
 
         // CLOB
@@ -76,7 +76,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("CLOB_COL"))
                 .build());
-        softly.assertThat(clobCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(clobCol.getType()).contains(Id.of("CLOB(1048576)"));
         softly.assertThat(clobCol.getTypeOriginal()).contains(Id.of("CLOB"));
 
         // XML
@@ -94,7 +94,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("GRAPHIC_COL"))
                 .build());
-        softly.assertThat(graphicCol.getType()).contains(Id.of("CHARACTER(1)"));
+        softly.assertThat(graphicCol.getType()).contains(Id.of("NCHAR(1)"));
         softly.assertThat(graphicCol.getTypeOriginal()).contains(Id.of("GRAPHIC"));
 
         // GRAPHIC(n)
@@ -103,7 +103,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("GRAPHIC_N_COL"))
                 .build());
-        softly.assertThat(graphicNCol.getType()).contains(Id.of("CHARACTER(10)"));
+        softly.assertThat(graphicNCol.getType()).contains(Id.of("NCHAR(10)"));
         softly.assertThat(graphicNCol.getTypeOriginal()).contains(Id.of("GRAPHIC"));
 
         // VARGRAPHIC(n)
@@ -112,7 +112,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("VARGRAPHIC_N_COL"))
                 .build());
-        softly.assertThat(vargraphicNCol.getType()).contains(Id.of("CHARACTER(100)"));
+        softly.assertThat(vargraphicNCol.getType()).contains(Id.of("NCHAR VARYING(100)"));
         softly.assertThat(vargraphicNCol.getTypeOriginal()).contains(Id.of("VARGRAPHIC"));
 
         // DBCLOB
@@ -121,7 +121,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("DBCLOB_COL"))
                 .build());
-        softly.assertThat(dbclobCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(dbclobCol.getType()).contains(Id.of("NCLOB(1048576)"));
         softly.assertThat(dbclobCol.getTypeOriginal()).contains(Id.of("DBCLOB"));
 
         // CHAR FOR BIT DATA
@@ -130,7 +130,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("CHAR_BIT_COL"))
                 .build());
-        softly.assertThat(charBitCol.getType()).contains(Id.of("BIT(8)"));
+        softly.assertThat(charBitCol.getType()).contains(Id.of("BINARY(1)"));
         softly.assertThat(charBitCol.getTypeOriginal()).contains(Id.of("CHAR () FOR BIT DATA"));
 
         // CHAR(n) FOR BIT DATA
@@ -139,7 +139,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("CHAR_N_BIT_COL"))
                 .build());
-        softly.assertThat(charNBitCol.getType()).contains(Id.of("BIT(128)"));
+        softly.assertThat(charNBitCol.getType()).contains(Id.of("BINARY(16)"));
         softly.assertThat(charNBitCol.getTypeOriginal()).contains(Id.of("CHAR () FOR BIT DATA"));
 
         // VARCHAR(n) FOR BIT DATA
@@ -148,7 +148,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("VARCHAR_N_BIT_COL"))
                 .build());
-        softly.assertThat(varcharNBitCol.getType()).contains(Id.of("BIT VARYING(800)"));
+        softly.assertThat(varcharNBitCol.getType()).contains(Id.of("VARBINARY(100)"));
         softly.assertThat(varcharNBitCol.getTypeOriginal()).contains(Id.of("VARCHAR () FOR BIT DATA"));
 
         // BLOB
@@ -157,7 +157,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("BLOB_COL"))
                 .build());
-        softly.assertThat(blobCol.getType()).contains(Id.of("BINARY LARGE OBJECT"));
+        softly.assertThat(blobCol.getType()).contains(Id.of("BLOB(1048576)"));
         softly.assertThat(blobCol.getTypeOriginal()).contains(Id.of("BLOB"));
 
         // SMALLINT
@@ -175,7 +175,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("INTEGER_COL"))
                 .build());
-        softly.assertThat(integerCol.getType()).contains(Id.of("INTEGER"));
+        softly.assertThat(integerCol.getType()).contains(Id.of("INT"));
         softly.assertThat(integerCol.getTypeOriginal()).contains(Id.of("INTEGER"));
 
         // BIGINT
@@ -184,7 +184,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("BIGINT_COL"))
                 .build());
-        softly.assertThat(bigintCol.getType()).contains(Id.of("DECIMAL(19)"));
+        softly.assertThat(bigintCol.getType()).contains(Id.of("BIGINT"));
         softly.assertThat(bigintCol.getTypeOriginal()).contains(Id.of("BIGINT"));
 
         // NUMERIC
@@ -193,8 +193,8 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("NUMERIC_COL"))
                 .build());
-        softly.assertThat(numericCol.getType()).contains(Id.of("DECIMAL(5)"));
-        softly.assertThat(numericCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+        softly.assertThat(numericCol.getType()).contains(Id.of("DEC(5)"));
+        softly.assertThat(numericCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
 
         // NUMERIC(p)
         val numericPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -202,8 +202,8 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("NUMERIC_P_COL"))
                 .build());
-        softly.assertThat(numericPCol.getType()).contains(Id.of("DECIMAL(10)"));
-        softly.assertThat(numericPCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+        softly.assertThat(numericPCol.getType()).contains(Id.of("DEC(10)"));
+        softly.assertThat(numericPCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
 
         // NUMERIC(p,s)
         val numericPSCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -211,8 +211,8 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("NUMERIC_PS_COL"))
                 .build());
-        softly.assertThat(numericPSCol.getType()).contains(Id.of("DECIMAL(10,2)"));
-        softly.assertThat(numericPSCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+        softly.assertThat(numericPSCol.getType()).contains(Id.of("DEC(10, 2)"));
+        softly.assertThat(numericPSCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
 
         // DECIMAL
         val decimalCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -220,7 +220,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("DECIMAL_COL"))
                 .build());
-        softly.assertThat(decimalCol.getType()).contains(Id.of("DECIMAL(5)"));
+        softly.assertThat(decimalCol.getType()).contains(Id.of("DEC(5)"));
         softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
 
         // DECIMAL(p)
@@ -229,7 +229,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("DECIMAL_P_COL"))
                 .build());
-        softly.assertThat(decimalPCol.getType()).contains(Id.of("DECIMAL(10)"));
+        softly.assertThat(decimalPCol.getType()).contains(Id.of("DEC(10)"));
         softly.assertThat(decimalPCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
 
         // DECIMAL(p,s)
@@ -238,7 +238,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("DECIMAL_PS_COL"))
                 .build());
-        softly.assertThat(decimalPSCol.getType()).contains(Id.of("DECIMAL(10,2)"));
+        softly.assertThat(decimalPSCol.getType()).contains(Id.of("DEC(10, 2)"));
         softly.assertThat(decimalPSCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
 
         // FLOAT
@@ -248,7 +248,7 @@ public class Db2DataTypeMappingIT {
                 .columnId(Id.of("FLOAT_COL"))
                 .build());
         softly.assertThat(floatCol.getType()).contains(Id.of("DOUBLE PRECISION"));
-        softly.assertThat(floatCol.getTypeOriginal()).contains(Id.of("FLOAT"));
+        softly.assertThat(floatCol.getTypeOriginal()).contains(Id.of("DOUBLE"));
 
         // FLOAT(p) where p <= 7
         val floatPSmallCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -257,7 +257,7 @@ public class Db2DataTypeMappingIT {
                 .columnId(Id.of("FLOAT_P_SMALL_COL"))
                 .build());
         softly.assertThat(floatPSmallCol.getType()).contains(Id.of("REAL"));
-        softly.assertThat(floatPSmallCol.getTypeOriginal()).contains(Id.of("FLOAT"));
+        softly.assertThat(floatPSmallCol.getTypeOriginal()).contains(Id.of("REAL"));
 
         // FLOAT(p) where p > 7
         val floatPLargeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -265,8 +265,8 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("FLOAT_P_LARGE_COL"))
                 .build());
-        softly.assertThat(floatPLargeCol.getType()).contains(Id.of("DOUBLE PRECISION"));
-        softly.assertThat(floatPLargeCol.getTypeOriginal()).contains(Id.of("FLOAT"));
+        softly.assertThat(floatPLargeCol.getType()).contains(Id.of("REAL"));
+        softly.assertThat(floatPLargeCol.getTypeOriginal()).contains(Id.of("REAL"));
 
         // REAL
         val realCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -310,7 +310,7 @@ public class Db2DataTypeMappingIT {
                 .tableId(Id.of("DATATYPE_MAPPING_TEST"))
                 .columnId(Id.of("TIMESTAMP_COL"))
                 .build());
-        softly.assertThat(timestampCol.getType()).contains(Id.of("TIMESTAMP(6)"));
+        softly.assertThat(timestampCol.getType()).contains(Id.of("TIMESTAMP"));
         softly.assertThat(timestampCol.getTypeOriginal()).contains(Id.of("TIMESTAMP"));
 
         // TIMESTAMP(n)

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/db2/issues/siardsuite163/Db2DataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/db2/issues/siardsuite163/Db2DataTypeMappingIT.java
@@ -1,0 +1,327 @@
+package ch.admin.bar.siard2.cmd.db2.issues.siardsuite163;
+
+import ch.admin.bar.siard2.cmd.SiardFromDb;
+import ch.admin.bar.siard2.cmd.utils.SqlScripts;
+import ch.admin.bar.siard2.cmd.utils.siard.SiardArchivesHandler;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.Id;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.QualifiedColumnId;
+import lombok.val;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.Db2Container;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class Db2DataTypeMappingIT {
+
+    @Rule
+    public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
+
+    @Rule
+    public Db2Container db = new Db2Container(DockerImageName.parse("ibmcom/db2:11.5.8.0"))
+            .acceptLicense()
+            .withInitScript(SqlScripts.Db2.SIARDSUITE_163_DATATYPE_MAPPING);
+
+    @Test
+    public void downloadArchive() throws SQLException, IOException, ClassNotFoundException {
+        val siardArchive = siardArchivesHandler.prepareEmpty();
+
+        SiardFromDb dbToSiard = new SiardFromDb(new String[]{
+                "-o",
+                "-j:" + db.getJdbcUrl(),
+                "-u:" + db.getUsername(),
+                "-p:" + db.getPassword(),
+                "-s:" + siardArchive.getPathToArchiveFile()
+        });
+
+        Assert.assertEquals(SiardFromDb.iRETURN_OK, dbToSiard.getReturn());
+
+        val metadataExplorer = siardArchive.exploreMetadata();
+        val softly = new SoftAssertions();
+
+        // CHAR
+        val charCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CHAR_COL"))
+                .build());
+        softly.assertThat(charCol.getType()).contains(Id.of("CHARACTER(1)"));
+        softly.assertThat(charCol.getTypeOriginal()).contains(Id.of("CHAR"));
+
+        // CHAR(n)
+        val charNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CHAR_N_COL"))
+                .build());
+        softly.assertThat(charNCol.getType()).contains(Id.of("CHARACTER(10)"));
+        softly.assertThat(charNCol.getTypeOriginal()).contains(Id.of("CHAR"));
+
+        // VARCHAR(n)
+        val varcharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("VARCHAR_N_COL"))
+                .build());
+        softly.assertThat(varcharNCol.getType()).contains(Id.of("CHARACTER VARYING(100)"));
+        softly.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("VARCHAR"));
+
+        // CLOB
+        val clobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CLOB_COL"))
+                .build());
+        softly.assertThat(clobCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(clobCol.getTypeOriginal()).contains(Id.of("CLOB"));
+
+        // XML
+        val xmlCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("XML_COL"))
+                .build());
+        softly.assertThat(xmlCol.getType()).contains(Id.of("XML"));
+        softly.assertThat(xmlCol.getTypeOriginal()).contains(Id.of("XML"));
+
+        // GRAPHIC
+        val graphicCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("GRAPHIC_COL"))
+                .build());
+        softly.assertThat(graphicCol.getType()).contains(Id.of("CHARACTER(1)"));
+        softly.assertThat(graphicCol.getTypeOriginal()).contains(Id.of("GRAPHIC"));
+
+        // GRAPHIC(n)
+        val graphicNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("GRAPHIC_N_COL"))
+                .build());
+        softly.assertThat(graphicNCol.getType()).contains(Id.of("CHARACTER(10)"));
+        softly.assertThat(graphicNCol.getTypeOriginal()).contains(Id.of("GRAPHIC"));
+
+        // VARGRAPHIC(n)
+        val vargraphicNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("VARGRAPHIC_N_COL"))
+                .build());
+        softly.assertThat(vargraphicNCol.getType()).contains(Id.of("CHARACTER(100)"));
+        softly.assertThat(vargraphicNCol.getTypeOriginal()).contains(Id.of("VARGRAPHIC"));
+
+        // DBCLOB
+        val dbclobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DBCLOB_COL"))
+                .build());
+        softly.assertThat(dbclobCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(dbclobCol.getTypeOriginal()).contains(Id.of("DBCLOB"));
+
+        // CHAR FOR BIT DATA
+        val charBitCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CHAR_BIT_COL"))
+                .build());
+        softly.assertThat(charBitCol.getType()).contains(Id.of("BIT(8)"));
+        softly.assertThat(charBitCol.getTypeOriginal()).contains(Id.of("CHAR () FOR BIT DATA"));
+
+        // CHAR(n) FOR BIT DATA
+        val charNBitCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CHAR_N_BIT_COL"))
+                .build());
+        softly.assertThat(charNBitCol.getType()).contains(Id.of("BIT(128)"));
+        softly.assertThat(charNBitCol.getTypeOriginal()).contains(Id.of("CHAR () FOR BIT DATA"));
+
+        // VARCHAR(n) FOR BIT DATA
+        val varcharNBitCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("VARCHAR_N_BIT_COL"))
+                .build());
+        softly.assertThat(varcharNBitCol.getType()).contains(Id.of("BIT VARYING(800)"));
+        softly.assertThat(varcharNBitCol.getTypeOriginal()).contains(Id.of("VARCHAR () FOR BIT DATA"));
+
+        // BLOB
+        val blobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("BLOB_COL"))
+                .build());
+        softly.assertThat(blobCol.getType()).contains(Id.of("BINARY LARGE OBJECT"));
+        softly.assertThat(blobCol.getTypeOriginal()).contains(Id.of("BLOB"));
+
+        // SMALLINT
+        val smallintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("SMALLINT_COL"))
+                .build());
+        softly.assertThat(smallintCol.getType()).contains(Id.of("SMALLINT"));
+        softly.assertThat(smallintCol.getTypeOriginal()).contains(Id.of("SMALLINT"));
+
+        // INTEGER
+        val integerCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("INTEGER_COL"))
+                .build());
+        softly.assertThat(integerCol.getType()).contains(Id.of("INTEGER"));
+        softly.assertThat(integerCol.getTypeOriginal()).contains(Id.of("INTEGER"));
+
+        // BIGINT
+        val bigintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("BIGINT_COL"))
+                .build());
+        softly.assertThat(bigintCol.getType()).contains(Id.of("DECIMAL(19)"));
+        softly.assertThat(bigintCol.getTypeOriginal()).contains(Id.of("BIGINT"));
+
+        // NUMERIC
+        val numericCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUMERIC_COL"))
+                .build());
+        softly.assertThat(numericCol.getType()).contains(Id.of("DECIMAL(5)"));
+        softly.assertThat(numericCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+
+        // NUMERIC(p)
+        val numericPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUMERIC_P_COL"))
+                .build());
+        softly.assertThat(numericPCol.getType()).contains(Id.of("DECIMAL(10)"));
+        softly.assertThat(numericPCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+
+        // NUMERIC(p,s)
+        val numericPSCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUMERIC_PS_COL"))
+                .build());
+        softly.assertThat(numericPSCol.getType()).contains(Id.of("DECIMAL(10,2)"));
+        softly.assertThat(numericPSCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+
+        // DECIMAL
+        val decimalCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DECIMAL_COL"))
+                .build());
+        softly.assertThat(decimalCol.getType()).contains(Id.of("DECIMAL(5)"));
+        softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
+
+        // DECIMAL(p)
+        val decimalPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DECIMAL_P_COL"))
+                .build());
+        softly.assertThat(decimalPCol.getType()).contains(Id.of("DECIMAL(10)"));
+        softly.assertThat(decimalPCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
+
+        // DECIMAL(p,s)
+        val decimalPSCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DECIMAL_PS_COL"))
+                .build());
+        softly.assertThat(decimalPSCol.getType()).contains(Id.of("DECIMAL(10,2)"));
+        softly.assertThat(decimalPSCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
+
+        // FLOAT
+        val floatCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("FLOAT_COL"))
+                .build());
+        softly.assertThat(floatCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        softly.assertThat(floatCol.getTypeOriginal()).contains(Id.of("FLOAT"));
+
+        // FLOAT(p) where p <= 7
+        val floatPSmallCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("FLOAT_P_SMALL_COL"))
+                .build());
+        softly.assertThat(floatPSmallCol.getType()).contains(Id.of("REAL"));
+        softly.assertThat(floatPSmallCol.getTypeOriginal()).contains(Id.of("FLOAT"));
+
+        // FLOAT(p) where p > 7
+        val floatPLargeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("FLOAT_P_LARGE_COL"))
+                .build());
+        softly.assertThat(floatPLargeCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        softly.assertThat(floatPLargeCol.getTypeOriginal()).contains(Id.of("FLOAT"));
+
+        // REAL
+        val realCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("REAL_COL"))
+                .build());
+        softly.assertThat(realCol.getType()).contains(Id.of("REAL"));
+        softly.assertThat(realCol.getTypeOriginal()).contains(Id.of("REAL"));
+
+        // DOUBLE
+        val doubleCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DOUBLE_COL"))
+                .build());
+        softly.assertThat(doubleCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        softly.assertThat(doubleCol.getTypeOriginal()).contains(Id.of("DOUBLE"));
+
+        // DATE
+        val dateCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DATE_COL"))
+                .build());
+        softly.assertThat(dateCol.getType()).contains(Id.of("DATE"));
+        softly.assertThat(dateCol.getTypeOriginal()).contains(Id.of("DATE"));
+
+        // TIME
+        val timeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("TIME_COL"))
+                .build());
+        softly.assertThat(timeCol.getType()).contains(Id.of("TIME"));
+        softly.assertThat(timeCol.getTypeOriginal()).contains(Id.of("TIME"));
+
+        // TIMESTAMP
+        val timestampCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("TIMESTAMP_COL"))
+                .build());
+        softly.assertThat(timestampCol.getType()).contains(Id.of("TIMESTAMP(6)"));
+        softly.assertThat(timestampCol.getTypeOriginal()).contains(Id.of("TIMESTAMP"));
+
+        // TIMESTAMP(n)
+        val timestampNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DB2INST1"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("TIMESTAMP_N_COL"))
+                .build());
+        softly.assertThat(timestampNCol.getType()).contains(Id.of("TIMESTAMP(9)"));
+        softly.assertThat(timestampNCol.getTypeOriginal()).contains(Id.of("TIMESTAMP"));
+
+        softly.assertAll();
+    }
+}

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/msaccess/issues/siardsuite163/MSAccessDataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/msaccess/issues/siardsuite163/MSAccessDataTypeMappingIT.java
@@ -48,27 +48,27 @@ public class MSAccessDataTypeMappingIT {
         // TEXT (column COLTEXT)
         val textCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLTEXT");
         softly.assertThat(textCol.getTypeOriginal()).contains(Id.of("TEXT"));
-        softly.assertThat(textCol.getType()).contains(Id.of("CHARACTER VARYING(255)"));
+        softly.assertThat(textCol.getType()).contains(Id.of("VARCHAR(255)"));
 
         // MEMO (column COLMEMO)
         val memoCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLMEMO");
         softly.assertThat(memoCol.getTypeOriginal()).contains(Id.of("MEMO"));
-        softly.assertThat(memoCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(memoCol.getType()).contains(Id.of("CLOB"));
 
         // LONG (column COLLONG)
         val longCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLLONG");
-        softly.assertThat(longCol.getTypeOriginal()).contains(Id.of("INTEGER"));
-        softly.assertThat(longCol.getType()).contains(Id.of("INTEGER"));
+        softly.assertThat(longCol.getTypeOriginal()).contains(Id.of("LONG"));
+        softly.assertThat(longCol.getType()).contains(Id.of("INT"));
 
         // INT (column COLINT)
         val intCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLINT");
-        softly.assertThat(intCol.getTypeOriginal()).contains(Id.of("SMALLINT"));
+        softly.assertThat(intCol.getTypeOriginal()).contains(Id.of("INT"));
         softly.assertThat(intCol.getType()).contains(Id.of("SMALLINT"));
 
         // DECIMAL (column COLDECIMAL)
         val decimalCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLDECIMAL");
-        softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
-        softly.assertThat(decimalCol.getType()).contains(Id.of("NUMERIC(18,0)"));
+        softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+        softly.assertThat(decimalCol.getType()).contains(Id.of("NUMERIC(18)"));
 
         // DOUBLE (column COLDOUBLE)
         val doubleCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLDOUBLE");
@@ -77,70 +77,70 @@ public class MSAccessDataTypeMappingIT {
 
         // FLOAT (column COLFLOAT)
         val floatCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLFLOAT");
-        softly.assertThat(floatCol.getTypeOriginal()).contains(Id.of("REAL"));
+        softly.assertThat(floatCol.getTypeOriginal()).contains(Id.of("FLOAT"));
         softly.assertThat(floatCol.getType()).contains(Id.of("REAL"));
 
         // SHORT_DATE_TIME (column COLDATETIME)
         val datetimeCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLDATETIME");
-        softly.assertThat(datetimeCol.getTypeOriginal()).contains(Id.of("DATETIME"));
+        softly.assertThat(datetimeCol.getTypeOriginal()).contains(Id.of("SHORT_DATE_TIME"));
         softly.assertThat(datetimeCol.getType()).contains(Id.of("TIMESTAMP"));
 
         // MONEY (column COLMONEY)
         val moneyCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLMONEY");
-        softly.assertThat(moneyCol.getTypeOriginal()).contains(Id.of("CURRENCY"));
-        softly.assertThat(moneyCol.getType()).contains(Id.of("NUMERIC(19,4)"));
+        softly.assertThat(moneyCol.getTypeOriginal()).contains(Id.of("MONEY"));
+        softly.assertThat(moneyCol.getType()).contains(Id.of("DEC(19, 4)"));
 
         // BOOLEAN (column COLBOOLEAN)
         val booleanCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLBOOLEAN");
-        softly.assertThat(booleanCol.getTypeOriginal()).contains(Id.of("BIT"));
+        softly.assertThat(booleanCol.getTypeOriginal()).contains(Id.of("BOOLEAN"));
         softly.assertThat(booleanCol.getType()).contains(Id.of("BOOLEAN"));
 
         // HYPERLINK (column COLLINK)
         val hyperlinkCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLLINK");
-        softly.assertThat(hyperlinkCol.getTypeOriginal()).contains(Id.of("HYPERLINK"));
-        softly.assertThat(hyperlinkCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(hyperlinkCol.getTypeOriginal()).contains(Id.of("MEMO"));
+        softly.assertThat(hyperlinkCol.getType()).contains(Id.of("CLOB"));
 
         // ATTACHMENT (column COLATTACH)
         val attachmentCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLATTACH");
-        softly.assertThat(attachmentCol.getTypeOriginal()).contains(Id.of("ATTACHMENT"));
-        softly.assertThat(attachmentCol.getType()).contains(Id.of("BINARY LARGE OBJECT"));
+        softly.assertThat(attachmentCol.getTypeOriginal()).contains(Id.of("BLOB ARRAY[127]"));
+        softly.assertThat(attachmentCol.getType()).contains(Id.of("BLOB"));
 
         // ===== TACCESSSIMPLE =====
 
         // COUNTER (column CCOUNTER)
         val counterCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CCOUNTER");
-        softly.assertThat(counterCol.getTypeOriginal()).contains(Id.of("COUNTER"));
-        softly.assertThat(counterCol.getType()).contains(Id.of("INTEGER"));
+        softly.assertThat(counterCol.getTypeOriginal()).contains(Id.of("LONG"));
+        softly.assertThat(counterCol.getType()).contains(Id.of("INT"));
 
         // CHAR(n) (column CCHAR_254)
         val charNCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CCHAR_254");
-        softly.assertThat(charNCol.getTypeOriginal()).contains(Id.of("CHAR(254)"));
-        softly.assertThat(charNCol.getType()).contains(Id.of("CHARACTER(254)"));
+        softly.assertThat(charNCol.getTypeOriginal()).contains(Id.of("TEXT"));
+        softly.assertThat(charNCol.getType()).contains(Id.of("VARCHAR(254)"));
 
         // VARCHAR(n) (column CVARCHAR_254)
         val varcharNCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CVARCHAR_254");
-        softly.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("VARCHAR(254)"));
-        softly.assertThat(varcharNCol.getType()).contains(Id.of("CHARACTER VARYING(254)"));
+        softly.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("TEXT"));
+        softly.assertThat(varcharNCol.getType()).contains(Id.of("VARCHAR(254)"));
 
         // GUID (column CGUID)
         val guidCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CGUID");
         softly.assertThat(guidCol.getTypeOriginal()).contains(Id.of("GUID"));
-        softly.assertThat(guidCol.getType()).contains(Id.of("CHARACTER VARYING(36)"));
+        softly.assertThat(guidCol.getType()).contains(Id.of("CHAR(38)"));
 
         // BINARY (column CBINARY)
         val binaryCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CBINARY");
         softly.assertThat(binaryCol.getTypeOriginal()).contains(Id.of("BINARY"));
-        softly.assertThat(binaryCol.getType()).contains(Id.of("BIT(4080)"));
+        softly.assertThat(binaryCol.getType()).contains(Id.of("BINARY(510)"));
 
         // VARBINARY (column CVARBINARY)
         val varbinaryCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CVARBINARY");
-        softly.assertThat(varbinaryCol.getTypeOriginal()).contains(Id.of("VARBINARY"));
-        softly.assertThat(varbinaryCol.getType()).contains(Id.of("BIT VARYING(4080)"));
+        softly.assertThat(varbinaryCol.getTypeOriginal()).contains(Id.of("BINARY"));
+        softly.assertThat(varbinaryCol.getType()).contains(Id.of("BINARY(510)"));
 
         // DECIMAL(p,q) (column CDECIMAL_10_5)
         val decimalPqCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CDECIMAL_10_5");
-        softly.assertThat(decimalPqCol.getTypeOriginal()).contains(Id.of("DECIMAL(10,5)"));
-        softly.assertThat(decimalPqCol.getType()).contains(Id.of("NUMERIC(10,5)"));
+        softly.assertThat(decimalPqCol.getTypeOriginal()).contains(Id.of("NUMERIC"));
+        softly.assertThat(decimalPqCol.getType()).contains(Id.of("NUMERIC(10, 5)"));
 
         softly.assertAll();
     }

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/msaccess/issues/siardsuite163/MSAccessDataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/msaccess/issues/siardsuite163/MSAccessDataTypeMappingIT.java
@@ -1,0 +1,158 @@
+package ch.admin.bar.siard2.cmd.msaccess.issues.siardsuite163;
+
+import ch.admin.bar.siard2.cmd.SiardFromDb;
+import ch.admin.bar.siard2.cmd.utils.siard.SiardArchivesHandler;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.Id;
+import ch.admin.bar.siard2.cmd.utils.siard.model.header.Metadata;
+import ch.admin.bar.siard2.cmd.utils.siard.utils.MetadataExplorer;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.QualifiedColumnId;
+import lombok.val;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class MSAccessDataTypeMappingIT {
+
+    private static final String SCHEMA = "Admin";
+    private static final String TABLE_COMPLEX = "TABLETEST";
+    private static final String TABLE_SIMPLE = "TACCESSSIMPLE";
+
+    @Rule
+    public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
+
+    @Test
+    public void downloadArchive() throws SQLException, IOException, ClassNotFoundException {
+        val dbPath = "testfiles/testaccess.accdb";
+
+        val siardArchive = siardArchivesHandler.prepareEmpty();
+
+        SiardFromDb dbToSiard = new SiardFromDb(new String[]{
+                "-o",
+                "-j:" + "jdbc:access:" + dbPath,
+                "-u:Admin",
+                "-p:pw",
+                "-s:" + siardArchive.getPathToArchiveFile()
+        });
+
+        Assert.assertEquals(SiardFromDb.iRETURN_OK, dbToSiard.getReturn());
+
+        val metadataExplorer = siardArchive.exploreMetadata();
+        val softly = new SoftAssertions();
+
+        // ===== TABLETEST =====
+
+        // TEXT (column COLTEXT)
+        val textCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLTEXT");
+        softly.assertThat(textCol.getTypeOriginal()).contains(Id.of("TEXT"));
+        softly.assertThat(textCol.getType()).contains(Id.of("CHARACTER VARYING(255)"));
+
+        // MEMO (column COLMEMO)
+        val memoCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLMEMO");
+        softly.assertThat(memoCol.getTypeOriginal()).contains(Id.of("MEMO"));
+        softly.assertThat(memoCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+
+        // LONG (column COLLONG)
+        val longCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLLONG");
+        softly.assertThat(longCol.getTypeOriginal()).contains(Id.of("INTEGER"));
+        softly.assertThat(longCol.getType()).contains(Id.of("INTEGER"));
+
+        // INT (column COLINT)
+        val intCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLINT");
+        softly.assertThat(intCol.getTypeOriginal()).contains(Id.of("SMALLINT"));
+        softly.assertThat(intCol.getType()).contains(Id.of("SMALLINT"));
+
+        // DECIMAL (column COLDECIMAL)
+        val decimalCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLDECIMAL");
+        softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("DECIMAL"));
+        softly.assertThat(decimalCol.getType()).contains(Id.of("NUMERIC(18,0)"));
+
+        // DOUBLE (column COLDOUBLE)
+        val doubleCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLDOUBLE");
+        softly.assertThat(doubleCol.getTypeOriginal()).contains(Id.of("DOUBLE"));
+        softly.assertThat(doubleCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+
+        // FLOAT (column COLFLOAT)
+        val floatCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLFLOAT");
+        softly.assertThat(floatCol.getTypeOriginal()).contains(Id.of("REAL"));
+        softly.assertThat(floatCol.getType()).contains(Id.of("REAL"));
+
+        // SHORT_DATE_TIME (column COLDATETIME)
+        val datetimeCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLDATETIME");
+        softly.assertThat(datetimeCol.getTypeOriginal()).contains(Id.of("DATETIME"));
+        softly.assertThat(datetimeCol.getType()).contains(Id.of("TIMESTAMP"));
+
+        // MONEY (column COLMONEY)
+        val moneyCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLMONEY");
+        softly.assertThat(moneyCol.getTypeOriginal()).contains(Id.of("CURRENCY"));
+        softly.assertThat(moneyCol.getType()).contains(Id.of("NUMERIC(19,4)"));
+
+        // BOOLEAN (column COLBOOLEAN)
+        val booleanCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLBOOLEAN");
+        softly.assertThat(booleanCol.getTypeOriginal()).contains(Id.of("BIT"));
+        softly.assertThat(booleanCol.getType()).contains(Id.of("BOOLEAN"));
+
+        // HYPERLINK (column COLLINK)
+        val hyperlinkCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLLINK");
+        softly.assertThat(hyperlinkCol.getTypeOriginal()).contains(Id.of("HYPERLINK"));
+        softly.assertThat(hyperlinkCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+
+        // ATTACHMENT (column COLATTACH)
+        val attachmentCol = findColumn(metadataExplorer, TABLE_COMPLEX, "COLATTACH");
+        softly.assertThat(attachmentCol.getTypeOriginal()).contains(Id.of("ATTACHMENT"));
+        softly.assertThat(attachmentCol.getType()).contains(Id.of("BINARY LARGE OBJECT"));
+
+        // ===== TACCESSSIMPLE =====
+
+        // COUNTER (column CCOUNTER)
+        val counterCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CCOUNTER");
+        softly.assertThat(counterCol.getTypeOriginal()).contains(Id.of("COUNTER"));
+        softly.assertThat(counterCol.getType()).contains(Id.of("INTEGER"));
+
+        // CHAR(n) (column CCHAR_254)
+        val charNCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CCHAR_254");
+        softly.assertThat(charNCol.getTypeOriginal()).contains(Id.of("CHAR(254)"));
+        softly.assertThat(charNCol.getType()).contains(Id.of("CHARACTER(254)"));
+
+        // VARCHAR(n) (column CVARCHAR_254)
+        val varcharNCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CVARCHAR_254");
+        softly.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("VARCHAR(254)"));
+        softly.assertThat(varcharNCol.getType()).contains(Id.of("CHARACTER VARYING(254)"));
+
+        // GUID (column CGUID)
+        val guidCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CGUID");
+        softly.assertThat(guidCol.getTypeOriginal()).contains(Id.of("GUID"));
+        softly.assertThat(guidCol.getType()).contains(Id.of("CHARACTER VARYING(36)"));
+
+        // BINARY (column CBINARY)
+        val binaryCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CBINARY");
+        softly.assertThat(binaryCol.getTypeOriginal()).contains(Id.of("BINARY"));
+        softly.assertThat(binaryCol.getType()).contains(Id.of("BIT(4080)"));
+
+        // VARBINARY (column CVARBINARY)
+        val varbinaryCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CVARBINARY");
+        softly.assertThat(varbinaryCol.getTypeOriginal()).contains(Id.of("VARBINARY"));
+        softly.assertThat(varbinaryCol.getType()).contains(Id.of("BIT VARYING(4080)"));
+
+        // DECIMAL(p,q) (column CDECIMAL_10_5)
+        val decimalPqCol = findColumn(metadataExplorer, TABLE_SIMPLE, "CDECIMAL_10_5");
+        softly.assertThat(decimalPqCol.getTypeOriginal()).contains(Id.of("DECIMAL(10,5)"));
+        softly.assertThat(decimalPqCol.getType()).contains(Id.of("NUMERIC(10,5)"));
+
+        softly.assertAll();
+    }
+
+    private Metadata.Column findColumn(
+            MetadataExplorer metadataExplorer,
+            String tableName,
+            String columnName) {
+        return metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of(SCHEMA))
+                .tableId(Id.of(tableName))
+                .columnId(Id.of(columnName))
+                .build());
+    }
+}

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mssql/issues/siardsuite163/MsSqlDataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mssql/issues/siardsuite163/MsSqlDataTypeMappingIT.java
@@ -1,0 +1,390 @@
+package ch.admin.bar.siard2.cmd.mssql.issues.siardsuite163;
+
+import ch.admin.bar.siard2.cmd.SiardFromDb;
+import ch.admin.bar.siard2.cmd.utils.SqlScripts;
+import ch.admin.bar.siard2.cmd.utils.siard.SiardArchivesHandler;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.Id;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.QualifiedColumnId;
+import lombok.val;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class MsSqlDataTypeMappingIT {
+
+    @Rule
+    public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
+
+    @Rule
+    public MSSQLServerContainer<?> db = new MSSQLServerContainer<>(DockerImageName.parse("mcr.microsoft.com/mssql/server:2017-CU12"))
+            .acceptLicense()
+            .withInitScript(SqlScripts.MsSQL.SIARDSUITE_163_DATATYPE_MAPPING);
+
+    @Test
+    public void downloadArchive() throws SQLException, IOException, ClassNotFoundException {
+        val siardArchive = siardArchivesHandler.prepareEmpty();
+
+        SiardFromDb dbToSiard = new SiardFromDb(new String[]{
+                "-o",
+                "-j:" + db.getJdbcUrl(),
+                "-u:" + db.getUsername(),
+                "-p:" + db.getPassword(),
+                "-s:" + siardArchive.getPathToArchiveFile()
+        });
+
+        Assert.assertEquals(SiardFromDb.iRETURN_OK, dbToSiard.getReturn());
+
+        val metadataExplorer = siardArchive.exploreMetadata();
+        val softly = new SoftAssertions();
+
+        // CHAR
+        val charCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("char_col"))
+                .build());
+        softly.assertThat(charCol.getType()).contains(Id.of("CHARACTER(1)"));
+        softly.assertThat(charCol.getTypeOriginal()).contains(Id.of("char"));
+
+        // CHAR(n)
+        val charNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("char_n_col"))
+                .build());
+        softly.assertThat(charNCol.getType()).contains(Id.of("CHARACTER(10)"));
+        softly.assertThat(charNCol.getTypeOriginal()).contains(Id.of("char(10)"));
+
+        // VARCHAR
+        val varcharCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varchar_col"))
+                .build());
+        softly.assertThat(varcharCol.getType()).contains(Id.of("CHARACTER VARYING(1)"));
+        softly.assertThat(varcharCol.getTypeOriginal()).contains(Id.of("varchar"));
+
+        // VARCHAR(n)
+        val varcharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varchar_n_col"))
+                .build());
+        softly.assertThat(varcharNCol.getType()).contains(Id.of("CHARACTER VARYING(100)"));
+        softly.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("varchar(100)"));
+
+        // TEXT
+        val textCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("text_col"))
+                .build());
+        softly.assertThat(textCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(textCol.getTypeOriginal()).contains(Id.of("text"));
+
+        // NCHAR
+        val ncharCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("nchar_col"))
+                .build());
+        softly.assertThat(ncharCol.getType()).contains(Id.of("NATIONAL CHARACTER(1)"));
+        softly.assertThat(ncharCol.getTypeOriginal()).contains(Id.of("nchar"));
+
+        // NCHAR(n)
+        val ncharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("nchar_n_col"))
+                .build());
+        softly.assertThat(ncharNCol.getType()).contains(Id.of("NATIONAL CHARACTER(10)"));
+        softly.assertThat(ncharNCol.getTypeOriginal()).contains(Id.of("nchar(10)"));
+
+        // NVARCHAR
+        val nvarcharCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("nvarchar_col"))
+                .build());
+        softly.assertThat(nvarcharCol.getType()).contains(Id.of("NATIONAL CHARACTER VARYING(1)"));
+        softly.assertThat(nvarcharCol.getTypeOriginal()).contains(Id.of("nvarchar"));
+
+        // NVARCHAR(n)
+        val nvarcharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("nvarchar_n_col"))
+                .build());
+        softly.assertThat(nvarcharNCol.getType()).contains(Id.of("NATIONAL CHARACTER VARYING(100)"));
+        softly.assertThat(nvarcharNCol.getTypeOriginal()).contains(Id.of("nvarchar(100)"));
+
+        // NTEXT
+        val ntextCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("ntext_col"))
+                .build());
+        softly.assertThat(ntextCol.getType()).contains(Id.of("NATIONAL CHARACTER LARGE OBJECT"));
+        softly.assertThat(ntextCol.getTypeOriginal()).contains(Id.of("ntext"));
+
+        // XML
+        val xmlCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("xml_col"))
+                .build());
+        softly.assertThat(xmlCol.getType()).contains(Id.of("XML"));
+        softly.assertThat(xmlCol.getTypeOriginal()).contains(Id.of("xml"));
+
+        // TINYINT
+        val tinyintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("tinyint_col"))
+                .build());
+        softly.assertThat(tinyintCol.getType()).contains(Id.of("SMALLINT"));
+        softly.assertThat(tinyintCol.getTypeOriginal()).contains(Id.of("tinyint"));
+
+        // SMALLINT
+        val smallintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("smallint_col"))
+                .build());
+        softly.assertThat(smallintCol.getType()).contains(Id.of("SMALLINT"));
+        softly.assertThat(smallintCol.getTypeOriginal()).contains(Id.of("smallint"));
+
+        // INT
+        val intCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("int_col"))
+                .build());
+        softly.assertThat(intCol.getType()).contains(Id.of("INTEGER"));
+        softly.assertThat(intCol.getTypeOriginal()).contains(Id.of("int"));
+
+        // BIGINT
+        val bigintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bigint_col"))
+                .build());
+        softly.assertThat(bigintCol.getType()).contains(Id.of("NUMERIC(19)"));
+        softly.assertThat(bigintCol.getTypeOriginal()).contains(Id.of("bigint"));
+
+        // NUMERIC
+        val numericCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_col"))
+                .build());
+        softly.assertThat(numericCol.getType()).contains(Id.of("NUMERIC(18)"));
+        softly.assertThat(numericCol.getTypeOriginal()).contains(Id.of("numeric"));
+
+        // NUMERIC(p)
+        val numericPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_p_col"))
+                .build());
+        softly.assertThat(numericPCol.getType()).contains(Id.of("NUMERIC(10)"));
+        softly.assertThat(numericPCol.getTypeOriginal()).contains(Id.of("numeric(10)"));
+
+        // NUMERIC(p,s)
+        val numericPSCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_ps_col"))
+                .build());
+        softly.assertThat(numericPSCol.getType()).contains(Id.of("NUMERIC(10,2)"));
+        softly.assertThat(numericPSCol.getTypeOriginal()).contains(Id.of("numeric(10,2)"));
+
+        // DECIMAL
+        val decimalCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_col"))
+                .build());
+        softly.assertThat(decimalCol.getType()).contains(Id.of("DECIMAL(18)"));
+        softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("decimal"));
+
+        // DECIMAL(p)
+        val decimalPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_p_col"))
+                .build());
+        softly.assertThat(decimalPCol.getType()).contains(Id.of("DECIMAL(10)"));
+        softly.assertThat(decimalPCol.getTypeOriginal()).contains(Id.of("decimal(10)"));
+
+        // DECIMAL(p,s)
+        val decimalPSCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_ps_col"))
+                .build());
+        softly.assertThat(decimalPSCol.getType()).contains(Id.of("DECIMAL(10,2)"));
+        softly.assertThat(decimalPSCol.getTypeOriginal()).contains(Id.of("decimal(10,2)"));
+
+        // SMALLMONEY
+        val smallmoneyCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("smallmoney_col"))
+                .build());
+        softly.assertThat(smallmoneyCol.getType()).contains(Id.of("DECIMAL(10,4)"));
+        softly.assertThat(smallmoneyCol.getTypeOriginal()).contains(Id.of("smallmoney"));
+
+        // MONEY
+        val moneyCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("money_col"))
+                .build());
+        softly.assertThat(moneyCol.getType()).contains(Id.of("DECIMAL(19,4)"));
+        softly.assertThat(moneyCol.getTypeOriginal()).contains(Id.of("money"));
+
+        // FLOAT
+        val floatCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_col"))
+                .build());
+        softly.assertThat(floatCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        softly.assertThat(floatCol.getTypeOriginal()).contains(Id.of("float"));
+
+        // FLOAT(p) where p <= 7
+        val floatPSmallCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_p_small_col"))
+                .build());
+        softly.assertThat(floatPSmallCol.getType()).contains(Id.of("REAL"));
+        softly.assertThat(floatPSmallCol.getTypeOriginal()).contains(Id.of("float"));
+
+        // FLOAT(p) where p > 7
+        val floatPLargeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_p_large_col"))
+                .build());
+        softly.assertThat(floatPLargeCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        softly.assertThat(floatPLargeCol.getTypeOriginal()).contains(Id.of("float"));
+
+        // REAL
+        val realCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("real_col"))
+                .build());
+        softly.assertThat(realCol.getType()).contains(Id.of("REAL"));
+        softly.assertThat(realCol.getTypeOriginal()).contains(Id.of("real"));
+
+        // BIT
+        val bitCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bit_col"))
+                .build());
+        softly.assertThat(bitCol.getType()).contains(Id.of("BOOLEAN"));
+        softly.assertThat(bitCol.getTypeOriginal()).contains(Id.of("bit"));
+
+        // BINARY
+        val binaryCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("binary_col"))
+                .build());
+        softly.assertThat(binaryCol.getType()).contains(Id.of("BIT(8)"));
+        softly.assertThat(binaryCol.getTypeOriginal()).contains(Id.of("binary"));
+
+        // BINARY(n)
+        val binaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("binary_n_col"))
+                .build());
+        softly.assertThat(binaryNCol.getType()).contains(Id.of("BIT(128)"));
+        softly.assertThat(binaryNCol.getTypeOriginal()).contains(Id.of("binary(16)"));
+
+        // VARBINARY
+        val varbinaryCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varbinary_col"))
+                .build());
+        softly.assertThat(varbinaryCol.getType()).contains(Id.of("BIT VARYING(8)"));
+        softly.assertThat(varbinaryCol.getTypeOriginal()).contains(Id.of("varbinary"));
+
+        // VARBINARY(n)
+        val varbinaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varbinary_n_col"))
+                .build());
+        softly.assertThat(varbinaryNCol.getType()).contains(Id.of("BIT VARYING(800)"));
+        softly.assertThat(varbinaryNCol.getTypeOriginal()).contains(Id.of("varbinary(100)"));
+
+        // IMAGE
+        val imageCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("image_col"))
+                .build());
+        softly.assertThat(imageCol.getType()).contains(Id.of("BINARY LARGE OBJECT"));
+        softly.assertThat(imageCol.getTypeOriginal()).contains(Id.of("image"));
+
+        // DATE
+        val dateCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("date_col"))
+                .build());
+        softly.assertThat(dateCol.getType()).contains(Id.of("DATE"));
+        softly.assertThat(dateCol.getTypeOriginal()).contains(Id.of("date"));
+
+        // TIME
+        val timeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("time_col"))
+                .build());
+        softly.assertThat(timeCol.getType()).contains(Id.of("TIME(7)"));
+        softly.assertThat(timeCol.getTypeOriginal()).contains(Id.of("time"));
+
+        // DATETIME
+        val datetimeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("datetime_col"))
+                .build());
+        softly.assertThat(datetimeCol.getType()).contains(Id.of("TIMESTAMP(7)"));
+        softly.assertThat(datetimeCol.getTypeOriginal()).contains(Id.of("datetime"));
+
+        // DATETIME2
+        val datetime2Col = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("datetime2_col"))
+                .build());
+        softly.assertThat(datetime2Col.getType()).contains(Id.of("TIMESTAMP(7)"));
+        softly.assertThat(datetime2Col.getTypeOriginal()).contains(Id.of("datetime2"));
+
+        // SMALLDATETIME
+        val smalldatetimeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("DataTypeMappingTest"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("smalldatetime_col"))
+                .build());
+        softly.assertThat(smalldatetimeCol.getType()).contains(Id.of("TIMESTAMP"));
+        softly.assertThat(smalldatetimeCol.getTypeOriginal()).contains(Id.of("smalldatetime"));
+
+        softly.assertAll();
+    }
+}

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mssql/issues/siardsuite163/MsSqlDataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mssql/issues/siardsuite163/MsSqlDataTypeMappingIT.java
@@ -49,8 +49,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("char_col"))
                 .build());
-        softly.assertThat(charCol.getType()).contains(Id.of("CHARACTER(1)"));
-        softly.assertThat(charCol.getTypeOriginal()).contains(Id.of("char"));
+        softly.assertThat(charCol.getType()).contains(Id.of("CHAR(1)"));
+        softly.assertThat(charCol.getTypeOriginal()).contains(Id.of("char(1)"));
 
         // CHAR(n)
         val charNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -58,7 +58,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("char_n_col"))
                 .build());
-        softly.assertThat(charNCol.getType()).contains(Id.of("CHARACTER(10)"));
+        softly.assertThat(charNCol.getType()).contains(Id.of("CHAR(10)"));
         softly.assertThat(charNCol.getTypeOriginal()).contains(Id.of("char(10)"));
 
         // VARCHAR
@@ -67,8 +67,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("varchar_col"))
                 .build());
-        softly.assertThat(varcharCol.getType()).contains(Id.of("CHARACTER VARYING(1)"));
-        softly.assertThat(varcharCol.getTypeOriginal()).contains(Id.of("varchar"));
+        softly.assertThat(varcharCol.getType()).contains(Id.of("VARCHAR(1)"));
+        softly.assertThat(varcharCol.getTypeOriginal()).contains(Id.of("varchar(1)"));
 
         // VARCHAR(n)
         val varcharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -76,7 +76,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("varchar_n_col"))
                 .build());
-        softly.assertThat(varcharNCol.getType()).contains(Id.of("CHARACTER VARYING(100)"));
+        softly.assertThat(varcharNCol.getType()).contains(Id.of("VARCHAR(100)"));
         softly.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("varchar(100)"));
 
         // TEXT
@@ -85,7 +85,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("text_col"))
                 .build());
-        softly.assertThat(textCol.getType()).contains(Id.of("CHARACTER LARGE OBJECT"));
+        softly.assertThat(textCol.getType()).contains(Id.of("CLOB"));
         softly.assertThat(textCol.getTypeOriginal()).contains(Id.of("text"));
 
         // NCHAR
@@ -94,8 +94,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("nchar_col"))
                 .build());
-        softly.assertThat(ncharCol.getType()).contains(Id.of("NATIONAL CHARACTER(1)"));
-        softly.assertThat(ncharCol.getTypeOriginal()).contains(Id.of("nchar"));
+        softly.assertThat(ncharCol.getType()).contains(Id.of("NCHAR(1)"));
+        softly.assertThat(ncharCol.getTypeOriginal()).contains(Id.of("nchar(1)"));
 
         // NCHAR(n)
         val ncharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -103,7 +103,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("nchar_n_col"))
                 .build());
-        softly.assertThat(ncharNCol.getType()).contains(Id.of("NATIONAL CHARACTER(10)"));
+        softly.assertThat(ncharNCol.getType()).contains(Id.of("NCHAR(10)"));
         softly.assertThat(ncharNCol.getTypeOriginal()).contains(Id.of("nchar(10)"));
 
         // NVARCHAR
@@ -112,8 +112,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("nvarchar_col"))
                 .build());
-        softly.assertThat(nvarcharCol.getType()).contains(Id.of("NATIONAL CHARACTER VARYING(1)"));
-        softly.assertThat(nvarcharCol.getTypeOriginal()).contains(Id.of("nvarchar"));
+        softly.assertThat(nvarcharCol.getType()).contains(Id.of("NCHAR VARYING(1)"));
+        softly.assertThat(nvarcharCol.getTypeOriginal()).contains(Id.of("nvarchar(1)"));
 
         // NVARCHAR(n)
         val nvarcharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -121,7 +121,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("nvarchar_n_col"))
                 .build());
-        softly.assertThat(nvarcharNCol.getType()).contains(Id.of("NATIONAL CHARACTER VARYING(100)"));
+        softly.assertThat(nvarcharNCol.getType()).contains(Id.of("NCHAR VARYING(100)"));
         softly.assertThat(nvarcharNCol.getTypeOriginal()).contains(Id.of("nvarchar(100)"));
 
         // NTEXT
@@ -130,7 +130,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("ntext_col"))
                 .build());
-        softly.assertThat(ntextCol.getType()).contains(Id.of("NATIONAL CHARACTER LARGE OBJECT"));
+        softly.assertThat(ntextCol.getType()).contains(Id.of("NCLOB"));
         softly.assertThat(ntextCol.getTypeOriginal()).contains(Id.of("ntext"));
 
         // XML
@@ -166,7 +166,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("int_col"))
                 .build());
-        softly.assertThat(intCol.getType()).contains(Id.of("INTEGER"));
+        softly.assertThat(intCol.getType()).contains(Id.of("INT"));
         softly.assertThat(intCol.getTypeOriginal()).contains(Id.of("int"));
 
         // BIGINT
@@ -175,7 +175,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("bigint_col"))
                 .build());
-        softly.assertThat(bigintCol.getType()).contains(Id.of("NUMERIC(19)"));
+        softly.assertThat(bigintCol.getType()).contains(Id.of("BIGINT"));
         softly.assertThat(bigintCol.getTypeOriginal()).contains(Id.of("bigint"));
 
         // NUMERIC
@@ -185,7 +185,7 @@ public class MsSqlDataTypeMappingIT {
                 .columnId(Id.of("numeric_col"))
                 .build());
         softly.assertThat(numericCol.getType()).contains(Id.of("NUMERIC(18)"));
-        softly.assertThat(numericCol.getTypeOriginal()).contains(Id.of("numeric"));
+        softly.assertThat(numericCol.getTypeOriginal()).contains(Id.of("numeric(18)"));
 
         // NUMERIC(p)
         val numericPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -202,7 +202,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("numeric_ps_col"))
                 .build());
-        softly.assertThat(numericPSCol.getType()).contains(Id.of("NUMERIC(10,2)"));
+        softly.assertThat(numericPSCol.getType()).contains(Id.of("NUMERIC(10, 2)"));
         softly.assertThat(numericPSCol.getTypeOriginal()).contains(Id.of("numeric(10,2)"));
 
         // DECIMAL
@@ -211,8 +211,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("decimal_col"))
                 .build());
-        softly.assertThat(decimalCol.getType()).contains(Id.of("DECIMAL(18)"));
-        softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("decimal"));
+        softly.assertThat(decimalCol.getType()).contains(Id.of("DEC(18)"));
+        softly.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("decimal(18)"));
 
         // DECIMAL(p)
         val decimalPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -220,7 +220,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("decimal_p_col"))
                 .build());
-        softly.assertThat(decimalPCol.getType()).contains(Id.of("DECIMAL(10)"));
+        softly.assertThat(decimalPCol.getType()).contains(Id.of("DEC(10)"));
         softly.assertThat(decimalPCol.getTypeOriginal()).contains(Id.of("decimal(10)"));
 
         // DECIMAL(p,s)
@@ -229,7 +229,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("decimal_ps_col"))
                 .build());
-        softly.assertThat(decimalPSCol.getType()).contains(Id.of("DECIMAL(10,2)"));
+        softly.assertThat(decimalPSCol.getType()).contains(Id.of("DEC(10, 2)"));
         softly.assertThat(decimalPSCol.getTypeOriginal()).contains(Id.of("decimal(10,2)"));
 
         // SMALLMONEY
@@ -238,7 +238,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("smallmoney_col"))
                 .build());
-        softly.assertThat(smallmoneyCol.getType()).contains(Id.of("DECIMAL(10,4)"));
+        softly.assertThat(smallmoneyCol.getType()).contains(Id.of("DEC(10, 4)"));
         softly.assertThat(smallmoneyCol.getTypeOriginal()).contains(Id.of("smallmoney"));
 
         // MONEY
@@ -247,7 +247,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("money_col"))
                 .build());
-        softly.assertThat(moneyCol.getType()).contains(Id.of("DECIMAL(19,4)"));
+        softly.assertThat(moneyCol.getType()).contains(Id.of("DEC(19, 4)"));
         softly.assertThat(moneyCol.getTypeOriginal()).contains(Id.of("money"));
 
         // FLOAT
@@ -266,7 +266,7 @@ public class MsSqlDataTypeMappingIT {
                 .columnId(Id.of("float_p_small_col"))
                 .build());
         softly.assertThat(floatPSmallCol.getType()).contains(Id.of("REAL"));
-        softly.assertThat(floatPSmallCol.getTypeOriginal()).contains(Id.of("float"));
+        softly.assertThat(floatPSmallCol.getTypeOriginal()).contains(Id.of("real"));
 
         // FLOAT(p) where p > 7
         val floatPLargeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -274,8 +274,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("float_p_large_col"))
                 .build());
-        softly.assertThat(floatPLargeCol.getType()).contains(Id.of("DOUBLE PRECISION"));
-        softly.assertThat(floatPLargeCol.getTypeOriginal()).contains(Id.of("float"));
+        softly.assertThat(floatPLargeCol.getType()).contains(Id.of("REAL"));
+        softly.assertThat(floatPLargeCol.getTypeOriginal()).contains(Id.of("real"));
 
         // REAL
         val realCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -301,8 +301,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("binary_col"))
                 .build());
-        softly.assertThat(binaryCol.getType()).contains(Id.of("BIT(8)"));
-        softly.assertThat(binaryCol.getTypeOriginal()).contains(Id.of("binary"));
+        softly.assertThat(binaryCol.getType()).contains(Id.of("BINARY(1)"));
+        softly.assertThat(binaryCol.getTypeOriginal()).contains(Id.of("binary(1)"));
 
         // BINARY(n)
         val binaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -310,7 +310,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("binary_n_col"))
                 .build());
-        softly.assertThat(binaryNCol.getType()).contains(Id.of("BIT(128)"));
+        softly.assertThat(binaryNCol.getType()).contains(Id.of("BINARY(16)"));
         softly.assertThat(binaryNCol.getTypeOriginal()).contains(Id.of("binary(16)"));
 
         // VARBINARY
@@ -319,8 +319,8 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("varbinary_col"))
                 .build());
-        softly.assertThat(varbinaryCol.getType()).contains(Id.of("BIT VARYING(8)"));
-        softly.assertThat(varbinaryCol.getTypeOriginal()).contains(Id.of("varbinary"));
+        softly.assertThat(varbinaryCol.getType()).contains(Id.of("VARBINARY(1)"));
+        softly.assertThat(varbinaryCol.getTypeOriginal()).contains(Id.of("varbinary(1)"));
 
         // VARBINARY(n)
         val varbinaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -328,7 +328,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("varbinary_n_col"))
                 .build());
-        softly.assertThat(varbinaryNCol.getType()).contains(Id.of("BIT VARYING(800)"));
+        softly.assertThat(varbinaryNCol.getType()).contains(Id.of("VARBINARY(100)"));
         softly.assertThat(varbinaryNCol.getTypeOriginal()).contains(Id.of("varbinary(100)"));
 
         // IMAGE
@@ -337,7 +337,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("image_col"))
                 .build());
-        softly.assertThat(imageCol.getType()).contains(Id.of("BINARY LARGE OBJECT"));
+        softly.assertThat(imageCol.getType()).contains(Id.of("BLOB"));
         softly.assertThat(imageCol.getTypeOriginal()).contains(Id.of("image"));
 
         // DATE
@@ -356,7 +356,7 @@ public class MsSqlDataTypeMappingIT {
                 .columnId(Id.of("time_col"))
                 .build());
         softly.assertThat(timeCol.getType()).contains(Id.of("TIME(7)"));
-        softly.assertThat(timeCol.getTypeOriginal()).contains(Id.of("time"));
+        softly.assertThat(timeCol.getTypeOriginal()).contains(Id.of("time(7)"));
 
         // DATETIME
         val datetimeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
@@ -364,7 +364,7 @@ public class MsSqlDataTypeMappingIT {
                 .tableId(Id.of("datatype_mapping_test_table"))
                 .columnId(Id.of("datetime_col"))
                 .build());
-        softly.assertThat(datetimeCol.getType()).contains(Id.of("TIMESTAMP(7)"));
+        softly.assertThat(datetimeCol.getType()).contains(Id.of("TIMESTAMP(3)"));
         softly.assertThat(datetimeCol.getTypeOriginal()).contains(Id.of("datetime"));
 
         // DATETIME2
@@ -374,7 +374,7 @@ public class MsSqlDataTypeMappingIT {
                 .columnId(Id.of("datetime2_col"))
                 .build());
         softly.assertThat(datetime2Col.getType()).contains(Id.of("TIMESTAMP(7)"));
-        softly.assertThat(datetime2Col.getTypeOriginal()).contains(Id.of("datetime2"));
+        softly.assertThat(datetime2Col.getTypeOriginal()).contains(Id.of("datetime2(7)"));
 
         // SMALLDATETIME
         val smalldatetimeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mysql/issues/siardsuite163/MySql5DataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mysql/issues/siardsuite163/MySql5DataTypeMappingIT.java
@@ -1,0 +1,363 @@
+package ch.admin.bar.siard2.cmd.mysql.issues.siardsuite163;
+
+import ch.admin.bar.siard2.cmd.SiardFromDb;
+import ch.admin.bar.siard2.cmd.SupportedDbVersions;
+import ch.admin.bar.siard2.cmd.utils.SqlScripts;
+import ch.admin.bar.siard2.cmd.utils.siard.SiardArchivesHandler;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.Id;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.QualifiedColumnId;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class MySql5DataTypeMappingIT {
+
+    @Rule
+    public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
+
+    @Rule
+    public MySQLContainer<?> downloadDbMySql5 = new MySQLContainer<>(DockerImageName.parse(SupportedDbVersions.MY_SQL_5_7))
+            .withUsername("root")
+            .withPassword("public")
+            .withInitScript(SqlScripts.MySQL.SIARDSUITE_163_DATATYPE_MAPPING)
+            .withConfigurationOverride("mysql/config/mysql-version-support");
+
+    @Test
+    public void downloadArchiveMySql5() throws SQLException, IOException, ClassNotFoundException {
+        val siardArchive = siardArchivesHandler.prepareEmpty();
+
+        SiardFromDb dbToSiard = new SiardFromDb(new String[]{
+                "-o",
+                "-j:" + downloadDbMySql5.getJdbcUrl(),
+                "-u:" + "it_user",
+                "-p:" + "it_password",
+                "-s:" + siardArchive.getPathToArchiveFile()
+        });
+
+        Assert.assertEquals(SiardFromDb.iRETURN_OK, dbToSiard.getReturn());
+
+        val metadataExplorer = siardArchive.exploreMetadata();
+
+        // CHAR
+        val charCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("char_col"))
+                .build());
+        Assertions.assertThat(charCol.getType()).contains(Id.of("CHAR(1)"));
+        Assertions.assertThat(charCol.getTypeOriginal()).contains(Id.of("char(1)"));
+
+        // CHAR(n)
+        val charNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("char_n_col"))
+                .build());
+        Assertions.assertThat(charNCol.getType()).contains(Id.of("CHAR(10)"));
+        Assertions.assertThat(charNCol.getTypeOriginal()).contains(Id.of("char(10)"));
+
+        // VARCHAR(n)
+        val varcharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varchar_col"))
+                .build());
+        Assertions.assertThat(varcharNCol.getType()).contains(Id.of("VARCHAR(100)"));
+        Assertions.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("varchar(100)"));
+
+        // TINYTEXT
+        val tinytextCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("tinytext_col"))
+                .build());
+        Assertions.assertThat(tinytextCol.getType()).contains(Id.of("VARCHAR(255)"));
+        Assertions.assertThat(tinytextCol.getTypeOriginal()).contains(Id.of("tinytext"));
+
+        // TEXT
+        val textCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("text_col"))
+                .build());
+        Assertions.assertThat(textCol.getType()).contains(Id.of("CLOB(65535)"));
+        Assertions.assertThat(textCol.getTypeOriginal()).contains(Id.of("text"));
+
+        // MEDIUMTEXT
+        val mediumtextCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("mediumtext_col"))
+                .build());
+        Assertions.assertThat(mediumtextCol.getType()).contains(Id.of("CLOB(16777215)"));
+        Assertions.assertThat(mediumtextCol.getTypeOriginal()).contains(Id.of("mediumtext"));
+
+        // TINYINT
+        val tinyintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("tinyint_col"))
+                .build());
+        Assertions.assertThat(tinyintCol.getType()).contains(Id.of("SMALLINT"));
+        Assertions.assertThat(tinyintCol.getTypeOriginal()).contains(Id.of("tinyint(4)"));
+
+        // SMALLINT
+        val smallintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("smallint_col"))
+                .build());
+        Assertions.assertThat(smallintCol.getType()).contains(Id.of("SMALLINT"));
+        Assertions.assertThat(smallintCol.getTypeOriginal()).contains(Id.of("smallint(6)"));
+
+        // MEDIUMINT
+        val mediumintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("mediumint_col"))
+                .build());
+        Assertions.assertThat(mediumintCol.getType()).contains(Id.of("INT"));
+        Assertions.assertThat(mediumintCol.getTypeOriginal()).contains(Id.of("mediumint(9)"));
+
+        // INT
+        val intCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("int_col"))
+                .build());
+        Assertions.assertThat(intCol.getType()).contains(Id.of("INT"));
+        Assertions.assertThat(intCol.getTypeOriginal()).contains(Id.of("int(11)"));
+
+        // BIGINT
+        val bigintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bigint_col"))
+                .build());
+        Assertions.assertThat(bigintCol.getType()).contains(Id.of("BIGINT"));
+        Assertions.assertThat(bigintCol.getTypeOriginal()).contains(Id.of("bigint(20)"));
+
+        // DECIMAL
+        val decimalCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_col"))
+                .build());
+        Assertions.assertThat(decimalCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // DECIMAL(n)
+        val decimalNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_n_col"))
+                .build());
+        Assertions.assertThat(decimalNCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(decimalNCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // DECIMAL(p,q)
+        val decimalPQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_pq_col"))
+                .build());
+        Assertions.assertThat(decimalPQCol.getType()).contains(Id.of("DEC(10, 2)"));
+        Assertions.assertThat(decimalPQCol.getTypeOriginal()).contains(Id.of("decimal(10,2)"));
+
+        // NUMERIC
+        val numericCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_col"))
+                .build());
+        Assertions.assertThat(numericCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(numericCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // NUMERIC(n)
+        val numericNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_n_col"))
+                .build());
+        Assertions.assertThat(numericNCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(numericNCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // NUMERIC(p,q)
+        val numericPQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_pq_col"))
+                .build());
+        Assertions.assertThat(numericPQCol.getType()).contains(Id.of("DEC(10, 2)"));
+        Assertions.assertThat(numericPQCol.getTypeOriginal()).contains(Id.of("decimal(10,2)"));
+
+        // FLOAT
+        val floatCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_col"))
+                .build());
+        Assertions.assertThat(floatCol.getType()).contains(Id.of("FLOAT(12)"));
+        Assertions.assertThat(floatCol.getTypeOriginal()).contains(Id.of("float"));
+
+        // FLOAT(p)
+        val floatPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_p_col"))
+                .build());
+        Assertions.assertThat(floatPCol.getType()).contains(Id.of("FLOAT(12)"));
+        Assertions.assertThat(floatPCol.getTypeOriginal()).contains(Id.of("float"));
+
+        // FLOAT(p,q)
+        val floatPQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_pq_col"))
+                .build());
+        Assertions.assertThat(floatPQCol.getType()).contains(Id.of("FLOAT"));
+        Assertions.assertThat(floatPQCol.getTypeOriginal()).contains(Id.of("float(10,2)"));
+
+        // DOUBLE
+        val doubleCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("double_col"))
+                .build());
+        Assertions.assertThat(doubleCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        Assertions.assertThat(doubleCol.getTypeOriginal()).contains(Id.of("double"));
+
+        // DOUBLE(p,q)
+        val doublePQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("double_pq_col"))
+                .build());
+        Assertions.assertThat(doublePQCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        Assertions.assertThat(doublePQCol.getTypeOriginal()).contains(Id.of("double(15,5)"));
+
+        // BIT
+        val bitCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bit_col"))
+                .build());
+        Assertions.assertThat(bitCol.getType()).contains(Id.of("BOOLEAN"));
+        Assertions.assertThat(bitCol.getTypeOriginal()).contains(Id.of("bit(1)"));
+
+        // BIT(n)
+        val bitNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bit_n_col"))
+                .build());
+        Assertions.assertThat(bitNCol.getType()).contains(Id.of("BINARY(8)"));
+        Assertions.assertThat(bitNCol.getTypeOriginal()).contains(Id.of("bit(8)"));
+
+        // BINARY(n)
+        val binaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("binary_col"))
+                .build());
+        Assertions.assertThat(binaryNCol.getType()).contains(Id.of("BINARY(16)"));
+        Assertions.assertThat(binaryNCol.getTypeOriginal()).contains(Id.of("binary(16)"));
+
+        // VARBINARY(n)
+        val varbinaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varbinary_col"))
+                .build());
+        Assertions.assertThat(varbinaryNCol.getType()).contains(Id.of("VARBINARY(100)"));
+        Assertions.assertThat(varbinaryNCol.getTypeOriginal()).contains(Id.of("varbinary(100)"));
+
+        // TINYBLOB
+        val tinyblobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("tinyblob_col"))
+                .build());
+        Assertions.assertThat(tinyblobCol.getType()).contains(Id.of("VARBINARY(255)"));
+        Assertions.assertThat(tinyblobCol.getTypeOriginal()).contains(Id.of("tinyblob"));
+
+        // BLOB
+        val blobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("blob_col"))
+                .build());
+        Assertions.assertThat(blobCol.getType()).contains(Id.of("BLOB(65535)"));
+        Assertions.assertThat(blobCol.getTypeOriginal()).contains(Id.of("blob"));
+
+        // MEDIUMBLOB
+        val mediumblobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("mediumblob_col"))
+                .build());
+        Assertions.assertThat(mediumblobCol.getType()).contains(Id.of("BLOB(16777215)"));
+        Assertions.assertThat(mediumblobCol.getTypeOriginal()).contains(Id.of("mediumblob"));
+
+        // LONGBLOB
+        val longblobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("longblob_col"))
+                .build());
+        Assertions.assertThat(longblobCol.getType()).contains(Id.of("BLOB(2G)"));
+        Assertions.assertThat(longblobCol.getTypeOriginal()).contains(Id.of("longblob"));
+
+        // DATETIME
+        val datetimeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("datetime_col"))
+                .build());
+        Assertions.assertThat(datetimeCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(datetimeCol.getTypeOriginal()).contains(Id.of("datetime"));
+
+        // TIMESTAMP
+        val timestampCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("timestamp_col"))
+                .build());
+        Assertions.assertThat(timestampCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(timestampCol.getTypeOriginal()).contains(Id.of("timestamp"));
+
+        // DATE
+        val dateCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("date_col"))
+                .build());
+        Assertions.assertThat(dateCol.getType()).contains(Id.of("DATE"));
+        Assertions.assertThat(dateCol.getTypeOriginal()).contains(Id.of("date"));
+
+        // TIME
+        val timeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("time_col"))
+                .build());
+        Assertions.assertThat(timeCol.getType()).contains(Id.of("TIME"));
+        Assertions.assertThat(timeCol.getTypeOriginal()).contains(Id.of("time"));
+
+        // YEAR
+        val yearCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("year_col"))
+                .build());
+        Assertions.assertThat(yearCol.getType()).contains(Id.of("SMALLINT"));
+        Assertions.assertThat(yearCol.getTypeOriginal()).contains(Id.of("year(4)"));
+    }
+}

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mysql/issues/siardsuite163/MySql8DataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/mysql/issues/siardsuite163/MySql8DataTypeMappingIT.java
@@ -1,0 +1,364 @@
+package ch.admin.bar.siard2.cmd.mysql.issues.siardsuite163;
+
+import ch.admin.bar.siard2.cmd.SiardFromDb;
+import ch.admin.bar.siard2.cmd.SupportedDbVersions;
+import ch.admin.bar.siard2.cmd.utils.SqlScripts;
+import ch.admin.bar.siard2.cmd.utils.siard.SiardArchivesHandler;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.Id;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.QualifiedColumnId;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class MySql8DataTypeMappingIT {
+
+    @Rule
+    public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
+
+    @Rule
+    public MySQLContainer<?> downloadDbMySql8 = new MySQLContainer<>(DockerImageName.parse(SupportedDbVersions.MY_SQL_8_4))
+            .withUsername("root")
+            .withPassword("public")
+            .withInitScript(SqlScripts.MySQL.SIARDSUITE_163_DATATYPE_MAPPING)
+            .withConfigurationOverride("mysql/config/mysql-version-support");
+
+    @Test
+    public void downloadArchiveMySql8() throws SQLException, IOException, ClassNotFoundException {
+        val siardArchive = siardArchivesHandler.prepareEmpty();
+
+        SiardFromDb dbToSiard = new SiardFromDb(new String[]{
+                "-o",
+                "-j:" + downloadDbMySql8.getJdbcUrl(),
+                "-u:" + "it_user",
+                "-p:" + "it_password",
+                "-s:" + siardArchive.getPathToArchiveFile()
+        });
+
+        Assert.assertEquals(SiardFromDb.iRETURN_OK, dbToSiard.getReturn());
+
+        val metadataExplorer = siardArchive.exploreMetadata();
+
+        // CHAR
+        val charCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("char_col"))
+                .build());
+        Assertions.assertThat(charCol.getType()).contains(Id.of("CHAR(1)"));
+        Assertions.assertThat(charCol.getTypeOriginal()).contains(Id.of("char(1)"));
+
+        // CHAR(n)
+        val charNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("char_n_col"))
+                .build());
+        Assertions.assertThat(charNCol.getType()).contains(Id.of("CHAR(10)"));
+        Assertions.assertThat(charNCol.getTypeOriginal()).contains(Id.of("char(10)"));
+
+        // VARCHAR(n)
+        val varcharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varchar_col"))
+                .build());
+        Assertions.assertThat(varcharNCol.getType()).contains(Id.of("VARCHAR(100)"));
+        Assertions.assertThat(varcharNCol.getTypeOriginal()).contains(Id.of("varchar(100)"));
+
+        // TINYTEXT
+        val tinytextCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("tinytext_col"))
+                .build());
+        Assertions.assertThat(tinytextCol.getType()).contains(Id.of("VARCHAR(255)"));
+        Assertions.assertThat(tinytextCol.getTypeOriginal()).contains(Id.of("tinytext"));
+
+        // TEXT
+        val textCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("text_col"))
+                .build());
+        Assertions.assertThat(textCol.getType()).contains(Id.of("CLOB(65535)"));
+        Assertions.assertThat(textCol.getTypeOriginal()).contains(Id.of("text"));
+
+        // MEDIUMTEXT
+        val mediumtextCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("mediumtext_col"))
+                .build());
+        Assertions.assertThat(mediumtextCol.getType()).contains(Id.of("CLOB(16777215)"));
+        Assertions.assertThat(mediumtextCol.getTypeOriginal()).contains(Id.of("mediumtext"));
+
+        // TINYINT
+        val tinyintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("tinyint_col"))
+                .build());
+        Assertions.assertThat(tinyintCol.getType()).contains(Id.of("SMALLINT"));
+        Assertions.assertThat(tinyintCol.getTypeOriginal()).contains(Id.of("tinyint"));
+
+        // SMALLINT
+        val smallintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("smallint_col"))
+                .build());
+        Assertions.assertThat(smallintCol.getType()).contains(Id.of("SMALLINT"));
+        Assertions.assertThat(smallintCol.getTypeOriginal()).contains(Id.of("smallint"));
+
+        // MEDIUMINT
+        val mediumintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("mediumint_col"))
+                .build());
+        Assertions.assertThat(mediumintCol.getType()).contains(Id.of("INT"));
+        Assertions.assertThat(mediumintCol.getTypeOriginal()).contains(Id.of("mediumint"));
+
+        // INT
+        val intCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("int_col"))
+                .build());
+        Assertions.assertThat(intCol.getType()).contains(Id.of("INT"));
+        Assertions.assertThat(intCol.getTypeOriginal()).contains(Id.of("int"));
+
+        // BIGINT
+        val bigintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bigint_col"))
+                .build());
+        Assertions.assertThat(bigintCol.getType()).contains(Id.of("BIGINT"));
+        Assertions.assertThat(bigintCol.getTypeOriginal()).contains(Id.of("bigint"));
+
+        // DECIMAL
+        val decimalCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_col"))
+                .build());
+        Assertions.assertThat(decimalCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // DECIMAL(n)
+        val decimalNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_n_col"))
+                .build());
+        Assertions.assertThat(decimalNCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(decimalNCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // DECIMAL(p,q)
+        val decimalPQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("decimal_pq_col"))
+                .build());
+        Assertions.assertThat(decimalPQCol.getType()).contains(Id.of("DEC(10, 2)"));
+        Assertions.assertThat(decimalPQCol.getTypeOriginal()).contains(Id.of("decimal(10,2)"));
+
+        // NUMERIC
+        val numericCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_col"))
+                .build());
+        Assertions.assertThat(numericCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(numericCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // NUMERIC(n)
+        val numericNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_n_col"))
+                .build());
+        Assertions.assertThat(numericNCol.getType()).contains(Id.of("DEC(10)"));
+        Assertions.assertThat(numericNCol.getTypeOriginal()).contains(Id.of("decimal(10,0)"));
+
+        // NUMERIC(p,q)
+        val numericPQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("numeric_pq_col"))
+                .build());
+        Assertions.assertThat(numericPQCol.getType()).contains(Id.of("DEC(10, 2)"));
+        Assertions.assertThat(numericPQCol.getTypeOriginal()).contains(Id.of("decimal(10,2)"));
+
+        // FLOAT
+        val floatCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_col"))
+                .build());
+        Assertions.assertThat(floatCol.getType()).contains(Id.of("FLOAT(12)"));
+        Assertions.assertThat(floatCol.getTypeOriginal()).contains(Id.of("float"));
+
+        // FLOAT(p)
+        val floatPCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_p_col"))
+                .build());
+        Assertions.assertThat(floatPCol.getType()).contains(Id.of("FLOAT(12)"));
+        Assertions.assertThat(floatPCol.getTypeOriginal()).contains(Id.of("float"));
+
+        // FLOAT(p,q)
+        val floatPQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("float_pq_col"))
+                .build());
+        Assertions.assertThat(floatPQCol.getType()).contains(Id.of("FLOAT"));
+        Assertions.assertThat(floatPQCol.getTypeOriginal()).contains(Id.of("float(10,2)"));
+
+        // DOUBLE
+        val doubleCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("double_col"))
+                .build());
+        Assertions.assertThat(doubleCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        Assertions.assertThat(doubleCol.getTypeOriginal()).contains(Id.of("double"));
+
+        // DOUBLE(p,q)
+        val doublePQCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("double_pq_col"))
+                .build());
+        Assertions.assertThat(doublePQCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        Assertions.assertThat(doublePQCol.getTypeOriginal()).contains(Id.of("double(15,5)"));
+
+        // BIT
+        val bitCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bit_col"))
+                .build());
+        Assertions.assertThat(bitCol.getType()).contains(Id.of("BOOLEAN"));
+        Assertions.assertThat(bitCol.getTypeOriginal()).contains(Id.of("bit(1)"));
+
+        // BIT(n)
+        val bitNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("bit_n_col"))
+                .build());
+        Assertions.assertThat(bitNCol.getType()).contains(Id.of("BINARY(8)"));
+        Assertions.assertThat(bitNCol.getTypeOriginal()).contains(Id.of("bit(8)"));
+
+        // BINARY(n)
+        val binaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("binary_col"))
+                .build());
+        Assertions.assertThat(binaryNCol.getType()).contains(Id.of("BINARY(16)"));
+        Assertions.assertThat(binaryNCol.getTypeOriginal()).contains(Id.of("binary(16)"));
+
+        // VARBINARY(n)
+        val varbinaryNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("varbinary_col"))
+                .build());
+        Assertions.assertThat(varbinaryNCol.getType()).contains(Id.of("VARBINARY(100)"));
+        Assertions.assertThat(varbinaryNCol.getTypeOriginal()).contains(Id.of("varbinary(100)"));
+
+        // TINYBLOB
+        val tinyblobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("tinyblob_col"))
+                .build());
+        Assertions.assertThat(tinyblobCol.getType()).contains(Id.of("VARBINARY(255)"));
+        Assertions.assertThat(tinyblobCol.getTypeOriginal()).contains(Id.of("tinyblob"));
+
+        // BLOB
+        val blobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("blob_col"))
+                .build());
+        Assertions.assertThat(blobCol.getType()).contains(Id.of("BLOB(65535)"));
+        Assertions.assertThat(blobCol.getTypeOriginal()).contains(Id.of("blob"));
+
+        // MEDIUMBLOB
+        val mediumblobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("mediumblob_col"))
+                .build());
+        Assertions.assertThat(mediumblobCol.getType()).contains(Id.of("BLOB(16777215)"));
+        Assertions.assertThat(mediumblobCol.getTypeOriginal()).contains(Id.of("mediumblob"));
+
+        // LONGBLOB
+        val longblobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("longblob_col"))
+                .build());
+        Assertions.assertThat(longblobCol.getType()).contains(Id.of("BLOB(2G)"));
+        Assertions.assertThat(longblobCol.getTypeOriginal()).contains(Id.of("longblob"));
+
+        // DATETIME
+        val datetimeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("datetime_col"))
+                .build());
+        Assertions.assertThat(datetimeCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(datetimeCol.getTypeOriginal()).contains(Id.of("datetime"));
+
+        // TIMESTAMP
+        val timestampCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("timestamp_col"))
+                .build());
+        Assertions.assertThat(timestampCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(timestampCol.getTypeOriginal()).contains(Id.of("timestamp"));
+
+        // DATE
+        val dateCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("date_col"))
+                .build());
+        Assertions.assertThat(dateCol.getType()).contains(Id.of("DATE"));
+        Assertions.assertThat(dateCol.getTypeOriginal()).contains(Id.of("date"));
+
+        // TIME
+        val timeCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("time_col"))
+                .build());
+        Assertions.assertThat(timeCol.getType()).contains(Id.of("TIME"));
+        Assertions.assertThat(timeCol.getTypeOriginal()).contains(Id.of("time"));
+
+        // YEAR
+        val yearCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("datatype_mapping_test"))
+                .tableId(Id.of("datatype_mapping_test_table"))
+                .columnId(Id.of("year_col"))
+                .build());
+        Assertions.assertThat(yearCol.getType()).contains(Id.of("SMALLINT"));
+        Assertions.assertThat(yearCol.getTypeOriginal()).contains(Id.of("year"));
+
+    }
+}

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/siardsuite163/OracleDataTypeMappingIT.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/siardsuite163/OracleDataTypeMappingIT.java
@@ -1,0 +1,311 @@
+package ch.admin.bar.siard2.cmd.oracle.issues.siardsuite163;
+
+import ch.admin.bar.siard2.cmd.SiardFromDb;
+import ch.admin.bar.siard2.cmd.utils.ConsoleLogConsumer;
+import ch.admin.bar.siard2.cmd.utils.SqlScripts;
+import ch.admin.bar.siard2.cmd.utils.TestResourcesResolver;
+import ch.admin.bar.siard2.cmd.utils.siard.SiardArchivesHandler;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.Id;
+import ch.admin.bar.siard2.cmd.utils.siard.model.utils.QualifiedColumnId;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class OracleDataTypeMappingIT {
+
+    @Rule
+    public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
+
+    @Rule
+    public OracleContainer db = new OracleContainer("gvenzl/oracle-xe:21-slim-faststart")
+            .withLogConsumer(new ConsoleLogConsumer())
+            .withCopyFileToContainer(
+                    MountableFile.forHostPath(TestResourcesResolver.resolve(SqlScripts.Oracle.CREATE_USER_WITH_ALL_PRIVILEGES).toPath()),
+                    "/container-entrypoint-initdb.d/00_create_user.sql")
+            .withCopyFileToContainer(
+                    MountableFile.forHostPath(TestResourcesResolver.resolve(SqlScripts.Oracle.SIARDSUITE_163_DATATYPE_MAPPING).toPath()),
+                    "/container-entrypoint-initdb.d/datatype-mapping.sql");
+
+    @Test
+    public void downloadArchive() throws SQLException, IOException, ClassNotFoundException {
+        val siardArchive = siardArchivesHandler.prepareEmpty();
+
+        SiardFromDb dbToSiard = new SiardFromDb(new String[]{
+                "-o",
+                "-j:" + db.getJdbcUrl(),
+                "-u:" + "IT_USER",
+                "-p:" + "password",
+                "-s:" + siardArchive.getPathToArchiveFile()
+        });
+
+        Assert.assertEquals(SiardFromDb.iRETURN_OK, dbToSiard.getReturn());
+
+        val metadataExplorer = siardArchive.exploreMetadata();
+
+        val id = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("ID"))
+                .build());
+        Assertions.assertThat(id.getType()).contains(Id.of("FLOAT(38)"));
+        Assertions.assertThat(id.getTypeOriginal()).contains(Id.of("NUMBER"));
+
+        val intCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("INT_COL"))
+                .build());
+        Assertions.assertThat(intCol.getType()).contains(Id.of("BIGINT"));
+        Assertions.assertThat(intCol.getTypeOriginal()).contains(Id.of("NUMBER"));
+
+        val numCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUM_COL"))
+                .build());
+        Assertions.assertThat(numCol.getType()).contains(Id.of("FLOAT(38)"));
+        Assertions.assertThat(numCol.getTypeOriginal()).contains(Id.of("NUMBER"));
+
+        val numPrecCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUM_PREC_COL"))
+                .build());
+        Assertions.assertThat(numPrecCol.getType()).contains(Id.of("INT"));
+        Assertions.assertThat(numPrecCol.getTypeOriginal()).contains(Id.of("NUMBER(10,0)"));
+
+        val numPrecScaleCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUM_PREC_SCALE_COL"))
+                .build());
+        Assertions.assertThat(numPrecScaleCol.getType()).contains(Id.of("DEC(10, 2)"));
+        Assertions.assertThat(numPrecScaleCol.getTypeOriginal()).contains(Id.of("NUMBER(10,2)"));
+
+        val smallintCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("SMALLINT_COL"))
+                .build());
+        Assertions.assertThat(smallintCol.getType()).contains(Id.of("BIGINT"));
+        Assertions.assertThat(smallintCol.getTypeOriginal()).contains(Id.of("NUMBER"));
+
+        val decimalCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DECIMAL_COL"))
+                .build());
+        Assertions.assertThat(decimalCol.getType()).contains(Id.of("BIGINT"));
+        Assertions.assertThat(decimalCol.getTypeOriginal()).contains(Id.of("NUMBER"));
+
+        val decimalPrecScaleCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DECIMAL_PREC_SCALE_COL"))
+                .build());
+        Assertions.assertThat(decimalPrecScaleCol.getType()).contains(Id.of("DEC(10, 2)"));
+        Assertions.assertThat(decimalPrecScaleCol.getTypeOriginal()).contains(Id.of("NUMBER(10,2)"));
+
+        val numericCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUMERIC_COL"))
+                .build());
+        Assertions.assertThat(numericCol.getType()).contains(Id.of("BIGINT"));
+        Assertions.assertThat(numericCol.getTypeOriginal()).contains(Id.of("NUMBER"));
+
+        val numericPrecScaleCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NUMERIC_PREC_SCALE_COL"))
+                .build());
+        Assertions.assertThat(numericPrecScaleCol.getType()).contains(Id.of("DEC(10, 2)"));
+        Assertions.assertThat(numericPrecScaleCol.getTypeOriginal()).contains(Id.of("NUMBER(10,2)"));
+
+        val floatCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("FLOAT_COL"))
+                .build());
+        Assertions.assertThat(floatCol.getType()).contains(Id.of("FLOAT(10)"));
+        Assertions.assertThat(floatCol.getTypeOriginal()).contains(Id.of("FLOAT(10)"));
+
+        val realCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("REAL_COL"))
+                .build());
+        Assertions.assertThat(realCol.getType()).contains(Id.of("FLOAT(63)"));
+        Assertions.assertThat(realCol.getTypeOriginal()).contains(Id.of("FLOAT(63)"));
+
+        val doublePrecCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DOUBLE_PREC_COL"))
+                .build());
+        Assertions.assertThat(doublePrecCol.getType()).contains(Id.of("FLOAT(126)"));
+        Assertions.assertThat(doublePrecCol.getTypeOriginal()).contains(Id.of("FLOAT(126)"));
+
+        val binaryFloatCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("BINARY_FLOAT_COL"))
+                .build());
+        Assertions.assertThat(binaryFloatCol.getType()).contains(Id.of("REAL"));
+        Assertions.assertThat(binaryFloatCol.getTypeOriginal()).contains(Id.of("BINARY_FLOAT"));
+
+        val binaryDoubleCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("BINARY_DOUBLE_COL"))
+                .build());
+        Assertions.assertThat(binaryDoubleCol.getType()).contains(Id.of("DOUBLE PRECISION"));
+        Assertions.assertThat(binaryDoubleCol.getTypeOriginal()).contains(Id.of("BINARY_DOUBLE"));
+
+        val charCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CHAR_COL"))
+                .build());
+        Assertions.assertThat(charCol.getType()).contains(Id.of("CHAR(1)"));
+        Assertions.assertThat(charCol.getTypeOriginal()).contains(Id.of("CHAR(1)"));
+
+        val charNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CHAR_N_COL"))
+                .build());
+        Assertions.assertThat(charNCol.getType()).contains(Id.of("CHAR(10)"));
+        Assertions.assertThat(charNCol.getTypeOriginal()).contains(Id.of("CHAR(10)"));
+
+        val varcharCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("VARCHAR_COL"))
+                .build());
+        Assertions.assertThat(varcharCol.getType()).contains(Id.of("VARCHAR(100)"));
+        Assertions.assertThat(varcharCol.getTypeOriginal()).contains(Id.of("VARCHAR2(100)"));
+
+        val varchar2Col = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("VARCHAR2_COL"))
+                .build());
+        Assertions.assertThat(varchar2Col.getType()).contains(Id.of("VARCHAR(100)"));
+        Assertions.assertThat(varchar2Col.getTypeOriginal()).contains(Id.of("VARCHAR2(100)"));
+
+        val nCharCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NCHAR_COL"))
+                .build());
+        //TODO is this a bug, 2 instead of 1?
+        Assertions.assertThat(nCharCol.getType()).contains(Id.of("NCHAR(2)"));
+        Assertions.assertThat(nCharCol.getTypeOriginal()).contains(Id.of("NCHAR(2)"));
+
+        val nCharNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NCHAR_N_COL"))
+                .build());
+        //TODO is this a bug, 20 instead of 10?
+        Assertions.assertThat(nCharNCol.getType()).contains(Id.of("NCHAR(20)"));
+        Assertions.assertThat(nCharNCol.getTypeOriginal()).contains(Id.of("NCHAR(20)"));
+
+        val nVarchar2Col = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NVARCHAR2_COL"))
+                .build());
+        //TODO is this a bug, 200 instead of 100?
+        Assertions.assertThat(nVarchar2Col.getType()).contains(Id.of("NCHAR VARYING(200)"));
+        Assertions.assertThat(nVarchar2Col.getTypeOriginal()).contains(Id.of("NVARCHAR2(200)"));
+
+        val clobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("CLOB_COL"))
+                .build());
+        Assertions.assertThat(clobCol.getType()).contains(Id.of("CLOB"));
+        Assertions.assertThat(clobCol.getTypeOriginal()).contains(Id.of("CLOB"));
+
+        val nClobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("NCLOB_COL"))
+                .build());
+        Assertions.assertThat(nClobCol.getType()).contains(Id.of("NCLOB"));
+        Assertions.assertThat(nClobCol.getTypeOriginal()).contains(Id.of("NCLOB"));
+
+        val blobCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("BLOB_COL"))
+                .build());
+        Assertions.assertThat(blobCol.getType()).contains(Id.of("BLOB"));
+        Assertions.assertThat(blobCol.getTypeOriginal()).contains(Id.of("BLOB"));
+
+        val rawCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("RAW_COL"))
+                .build());
+        Assertions.assertThat(rawCol.getType()).contains(Id.of("VARBINARY(100)"));
+        Assertions.assertThat(rawCol.getTypeOriginal()).contains(Id.of("RAW(100)"));
+
+        val longRawCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("LONGRAW_COL"))
+                .build());
+        Assertions.assertThat(longRawCol.getType()).contains(Id.of("BLOB"));
+        Assertions.assertThat(longRawCol.getTypeOriginal()).contains(Id.of("LONG RAW"));
+
+        val dateCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("DATE_COL"))
+                .build());
+        Assertions.assertThat(dateCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(dateCol.getTypeOriginal()).contains(Id.of("DATE"));
+
+        val timestampCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("TIMESTAMP_COL"))
+                .build());
+        Assertions.assertThat(timestampCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(timestampCol.getTypeOriginal()).contains(Id.of("TIMESTAMP(6)"));
+
+        val timestampNCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("TIMESTAMP_N_COL"))
+                .build());
+        Assertions.assertThat(timestampNCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(timestampNCol.getTypeOriginal()).contains(Id.of("TIMESTAMP(6)"));
+
+        val timestampTzCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("TIMESTAMP_TZ_COL"))
+                .build());
+        Assertions.assertThat(timestampTzCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(timestampTzCol.getTypeOriginal()).contains(Id.of("TIMESTAMP(6) WITH TIME ZONE"));
+
+        val timestampLtzCol = metadataExplorer.findByColumnId(QualifiedColumnId.builder()
+                .schemaId(Id.of("IT_USER"))
+                .tableId(Id.of("DATATYPE_MAPPING_TEST"))
+                .columnId(Id.of("TIMESTAMP_LTZ_COL"))
+                .build());
+        Assertions.assertThat(timestampLtzCol.getType()).contains(Id.of("TIMESTAMP"));
+        Assertions.assertThat(timestampLtzCol.getTypeOriginal()).contains(Id.of("TIMESTAMP(6) WITH LOCAL TIME ZONE"));
+    }
+}

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
@@ -37,5 +37,6 @@ public class SqlScripts {
         public final static String SIARDSUITE_115 = "mssql/issues/siardsuite115/mssql-varchar-types.sql";
         public final static String SIARDSUITE_125 = "mssql/issues/siardsuite125/mssql-bit-types.sql";
         public final static String SIARDSUITE_106_SCHEMA_NAME = "mssql/issues/siardsuite106/schema-with-underscore.sql";
+        public final static String SIARDSUITE_163_DATATYPE_MAPPING = "mssql/issues/siardsuite163/datatype-mapping-mssql.sql";
     }
 }

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
@@ -10,6 +10,7 @@ public class SqlScripts {
         public final static String SIARDSUITE_129_BINARY = "oracle/issues/siardsuite129/binary-types-schema.sql";
         public final static String SIARDSUITE_129_VARCHAR = "oracle/issues/siardsuite129/varchar-types-schema.sql";
         public final static String SIARDSUITE_106_SCHEMA_NAME = "oracle/issues/siardsuite106/schema-with-underscore.sql";
+        public final static String SIARDSUITE_163_DATATYPE_MAPPING = "oracle/issues/siardsuite163/datatype-mapping-oracle.sql";
     }
 
     public static class Postgres {
@@ -28,6 +29,7 @@ public class SqlScripts {
         public final static String JDBCMYSQL_4 = "mysql/issues/jdbcmysql4/nation.sql";
         public final static String JDBCMYSQL_4_WILDCARD = "mysql/issues/jdbcmysql4/wildcard.sql";
         public final static String SIARDSUITE_112 = "mysql/issues/siardsuite112/mysql-file-types.sql";
+        public final static String SIARDSUITE_163_DATATYPE_MAPPING = "mysql/issues/siardsuite163/datatype-mapping-mysql.sql";
     }
 
     public static class MsSQL {

--- a/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
+++ b/siard-cmd/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
@@ -32,6 +32,10 @@ public class SqlScripts {
         public final static String SIARDSUITE_163_DATATYPE_MAPPING = "mysql/issues/siardsuite163/datatype-mapping-mysql.sql";
     }
 
+    public static class Db2 {
+        public final static String SIARDSUITE_163_DATATYPE_MAPPING = "db2/issues/siardsuite163/datatype-mapping-db2.sql";
+    }
+
     public static class MsSQL {
         public final static String SIARDSUITE_112 = "mssql/issues/siardsuite112/mssql-file-types.sql";
         public final static String SIARDSUITE_115 = "mssql/issues/siardsuite115/mssql-varchar-types.sql";

--- a/siard-cmd/src/integrationTest/resources/db2/issues/siardsuite163/datatype-mapping-db2.sql
+++ b/siard-cmd/src/integrationTest/resources/db2/issues/siardsuite163/datatype-mapping-db2.sql
@@ -1,0 +1,93 @@
+CREATE TABLE DATATYPE_MAPPING_TEST
+(
+    ID                        INTEGER NOT NULL PRIMARY KEY,
+
+    -- Character types
+    CHAR_COL                  CHAR,
+    CHAR_N_COL                CHAR(10),
+    VARCHAR_N_COL             VARCHAR(100),
+    CLOB_COL                  CLOB,
+    XML_COL                   XML,
+
+    -- Graphic types
+    GRAPHIC_COL               GRAPHIC,
+    GRAPHIC_N_COL             GRAPHIC(10),
+    VARGRAPHIC_N_COL          VARGRAPHIC(100),
+    DBCLOB_COL                DBCLOB,
+
+    -- Binary string types
+    CHAR_BIT_COL              CHAR(1) FOR BIT DATA,
+    CHAR_N_BIT_COL            CHAR(16) FOR BIT DATA,
+    VARCHAR_N_BIT_COL         VARCHAR(100) FOR BIT DATA,
+    BLOB_COL                  BLOB,
+
+    -- Integer types
+    SMALLINT_COL              SMALLINT,
+    INTEGER_COL               INTEGER,
+    BIGINT_COL                BIGINT,
+
+    -- Numeric types
+    NUMERIC_COL               NUMERIC,
+    NUMERIC_P_COL             NUMERIC(10),
+    NUMERIC_PS_COL            NUMERIC(10, 2),
+    DECIMAL_COL               DECIMAL,
+    DECIMAL_P_COL             DECIMAL(10),
+    DECIMAL_PS_COL            DECIMAL(10, 2),
+
+    -- Floating-point types
+    FLOAT_COL                 FLOAT,
+    FLOAT_P_SMALL_COL         FLOAT(7),
+    FLOAT_P_LARGE_COL         FLOAT(10),
+    REAL_COL                  REAL,
+    DOUBLE_COL                DOUBLE,
+
+    -- Date/Time types
+    DATE_COL                  DATE,
+    TIME_COL                  TIME,
+    TIMESTAMP_COL             TIMESTAMP,
+    TIMESTAMP_N_COL           TIMESTAMP(9)
+);
+
+INSERT INTO DATATYPE_MAPPING_TEST
+    (ID,
+     CHAR_COL, CHAR_N_COL, VARCHAR_N_COL, CLOB_COL,
+     GRAPHIC_COL, GRAPHIC_N_COL, VARGRAPHIC_N_COL, DBCLOB_COL,
+     CHAR_BIT_COL, CHAR_N_BIT_COL, VARCHAR_N_BIT_COL, BLOB_COL,
+     SMALLINT_COL, INTEGER_COL, BIGINT_COL,
+     NUMERIC_COL, NUMERIC_P_COL, NUMERIC_PS_COL,
+     DECIMAL_COL, DECIMAL_P_COL, DECIMAL_PS_COL,
+     FLOAT_COL, FLOAT_P_SMALL_COL, FLOAT_P_LARGE_COL, REAL_COL, DOUBLE_COL,
+     DATE_COL, TIME_COL, TIMESTAMP_COL, TIMESTAMP_N_COL)
+VALUES
+    (1,
+     'A',                                                -- CHAR(1)
+     'ABCDEFGHIJ',                                       -- CHAR(10)
+     'Hello DB2',                                        -- VARCHAR(100)
+     'This is a clob value',                             -- CLOB
+     G'A',                                               -- GRAPHIC(1)
+     G'ABCDEFGHIJ',                                      -- GRAPHIC(10)
+     G'Hello',                                           -- VARGRAPHIC(100)
+     G'This is a dbclob',                                -- DBCLOB
+     X'01',                                              -- CHAR(1) FOR BIT DATA
+     X'00112233445566778899AABBCCDDEEFF',                -- CHAR(16) FOR BIT DATA
+     X'A1B2C3',                                          -- VARCHAR(100) FOR BIT DATA
+     BLOB(X'CAFEBABE'),                                  -- BLOB
+     32767,                                              -- SMALLINT
+     2147483647,                                         -- INTEGER
+     9223372036854775807,                                -- BIGINT
+     12345,                                              -- NUMERIC
+     1234567890,                                         -- NUMERIC(10)
+     12345678.90,                                        -- NUMERIC(10,2)
+     12345,                                              -- DECIMAL
+     1234567890,                                         -- DECIMAL(10)
+     12345678.90,                                        -- DECIMAL(10,2)
+     1.23456789012345E+100,                              -- FLOAT
+     1.2345,                                             -- FLOAT(7)
+     1.2345E+10,                                         -- FLOAT(10)
+     1.2345,                                             -- REAL
+     1.23456789012345E+100,                              -- DOUBLE
+     '2025-09-04',                                       -- DATE
+     '15.30.45',                                         -- TIME
+     '2025-09-04-15.30.45.123456',                       -- TIMESTAMP
+     '2025-09-04-15.30.45.123456789'                     -- TIMESTAMP(9)
+    );

--- a/siard-cmd/src/integrationTest/resources/mssql/issues/siardsuite163/datatype-mapping-mssql.sql
+++ b/siard-cmd/src/integrationTest/resources/mssql/issues/siardsuite163/datatype-mapping-mssql.sql
@@ -1,0 +1,110 @@
+CREATE SCHEMA [DataTypeMappingTest];
+
+CREATE TABLE [DataTypeMappingTest].[datatype_mapping_test_table]
+(
+    [id]               INT PRIMARY KEY,
+
+    -- Character types
+    [char_col]         CHAR,
+    [char_n_col]       CHAR(10),
+    [varchar_col]      VARCHAR,
+    [varchar_n_col]    VARCHAR(100),
+    [text_col]         TEXT,
+    [nchar_col]        NCHAR,
+    [nchar_n_col]      NCHAR(10),
+    [nvarchar_col]     NVARCHAR,
+    [nvarchar_n_col]   NVARCHAR(100),
+    [ntext_col]        NTEXT,
+    [xml_col]          XML,
+
+    -- Integer types
+    [tinyint_col]      TINYINT,
+    [smallint_col]     SMALLINT,
+    [int_col]          INT,
+    [bigint_col]       BIGINT,
+
+    -- Numeric types
+    [numeric_col]      NUMERIC,
+    [numeric_p_col]    NUMERIC(10),
+    [numeric_ps_col]   NUMERIC(10, 2),
+    [decimal_col]      DECIMAL,
+    [decimal_p_col]    DECIMAL(10),
+    [decimal_ps_col]   DECIMAL(10, 2),
+    [smallmoney_col]   SMALLMONEY,
+    [money_col]        MONEY,
+    [float_col]        FLOAT,
+    [float_p_small_col] FLOAT(7),
+    [float_p_large_col] FLOAT(10),
+    [real_col]         REAL,
+
+    -- Bit type
+    [bit_col]          BIT,
+
+    -- Binary types
+    [binary_col]       BINARY,
+    [binary_n_col]     BINARY(16),
+    [varbinary_col]    VARBINARY,
+    [varbinary_n_col]  VARBINARY(100),
+    [image_col]        IMAGE,
+
+    -- Date/Time types
+    [date_col]         DATE,
+    [time_col]         TIME,
+    [datetime_col]     DATETIME,
+    [datetime2_col]    DATETIME2,
+    [smalldatetime_col] SMALLDATETIME
+);
+
+INSERT INTO [DataTypeMappingTest].[datatype_mapping_test_table]
+    ([id],
+     [char_col], [char_n_col], [varchar_col], [varchar_n_col], [text_col],
+     [nchar_col], [nchar_n_col], [nvarchar_col], [nvarchar_n_col], [ntext_col], [xml_col],
+     [tinyint_col], [smallint_col], [int_col], [bigint_col],
+     [numeric_col], [numeric_p_col], [numeric_ps_col],
+     [decimal_col], [decimal_p_col], [decimal_ps_col],
+     [smallmoney_col], [money_col],
+     [float_col], [float_p_small_col], [float_p_large_col], [real_col],
+     [bit_col],
+     [binary_col], [binary_n_col], [varbinary_col], [varbinary_n_col], [image_col],
+     [date_col], [time_col], [datetime_col], [datetime2_col], [smalldatetime_col])
+VALUES
+    (1,
+     'A',                                                -- CHAR(1)
+     'ABCDEFGHIJ',                                       -- CHAR(10)
+     'V',                                                -- VARCHAR(1)
+     'Hello MSSQL',                                      -- VARCHAR(100)
+     'This is a text column',                            -- TEXT
+     N'N',                                               -- NCHAR(1)
+     N'ABCDEFGHIJ',                                      -- NCHAR(10)
+     N'N',                                               -- NVARCHAR(1)
+     N'Hello Unicode',                                   -- NVARCHAR(100)
+     N'This is ntext',                                   -- NTEXT
+     '<root><element>value</element></root>',            -- XML
+     255,                                                -- TINYINT
+     32767,                                              -- SMALLINT
+     2147483647,                                         -- INT
+     9223372036854775807,                                -- BIGINT
+     12345678901234567,                                  -- NUMERIC
+     1234567890,                                         -- NUMERIC(10)
+     12345678.90,                                        -- NUMERIC(10,2)
+     12345678901234567,                                  -- DECIMAL
+     1234567890,                                         -- DECIMAL(10)
+     12345678.90,                                        -- DECIMAL(10,2)
+     214748.3647,                                        -- SMALLMONEY
+     922337203685477.5807,                               -- MONEY
+     1.23456789012345E+100,                              -- FLOAT
+     1.2345,                                             -- FLOAT(7) p<=7 => real
+     1.2345E+10,                                         -- FLOAT(10) p>7 => float
+     1.2345,                                             -- REAL
+     1,                                                  -- BIT
+     0x01,                                               -- BINARY(1)
+     0x00112233445566778899AABBCCDDEEFF,                 -- BINARY(16)
+     0x01,                                               -- VARBINARY(1)
+     0xA1B2C3,                                           -- VARBINARY(100)
+     0xDEADBEEF,                                         -- IMAGE
+     '2025-09-04',                                       -- DATE
+     '15:30:45',                                         -- TIME
+     '2025-09-04 15:30:45',                              -- DATETIME
+     '2025-09-04 15:30:45.1234567',                      -- DATETIME2
+     '2025-09-04 15:30:00'                               -- SMALLDATETIME
+    );

--- a/siard-cmd/src/integrationTest/resources/mysql/issues/siardsuite163/datatype-mapping-mysql.sql
+++ b/siard-cmd/src/integrationTest/resources/mysql/issues/siardsuite163/datatype-mapping-mysql.sql
@@ -1,0 +1,115 @@
+-- Create it_user with privileges for nation and test databases
+CREATE USER 'it_user'@'%' IDENTIFIED BY 'it_password';
+GRANT ALL PRIVILEGES ON datatype_mapping_test.* TO 'it_user'@'%';
+GRANT ALL PRIVILEGES ON test.* TO 'it_user'@'%';
+
+-- Schema creation - with underscore in the name
+CREATE SCHEMA IF NOT EXISTS datatype_mapping_test;
+USE datatype_mapping_test;
+
+CREATE TABLE datatype_mapping_test_table
+(
+    id             INT PRIMARY KEY,
+
+    -- Character types
+    char_col       CHAR,
+    char_n_col     CHAR(10),
+    varchar_col    VARCHAR(100),
+    tinytext_col   TINYTEXT,
+    text_col       TEXT,
+    mediumtext_col MEDIUMTEXT,
+
+    -- Numeric types
+    tinyint_col    TINYINT,
+    smallint_col   SMALLINT,
+    mediumint_col  MEDIUMINT,
+    int_col        INT,
+    bigint_col     BIGINT,
+    decimal_col    DECIMAL,
+    decimal_n_col  DECIMAL(10),
+    decimal_pq_col DECIMAL(10, 2),
+    numeric_col    NUMERIC,
+    numeric_n_col  NUMERIC(10),
+    numeric_pq_col NUMERIC(10, 2),
+    float_col      FLOAT,
+    float_p_col    FLOAT(10),
+    float_pq_col   FLOAT(10, 2),
+    double_col     DOUBLE,
+    double_pq_col  DOUBLE(15, 5),
+
+    -- Bit and binary types
+    bit_col        BIT,
+    bit_n_col      BIT(8),
+    binary_col     BINARY(16),
+    varbinary_col  VARBINARY(100),
+
+    -- LOB / BLOB types
+    tinyblob_col   TINYBLOB,
+    blob_col       BLOB,
+    mediumblob_col MEDIUMBLOB,
+    longblob_col   LONGBLOB,
+
+    -- Temporal types
+    datetime_col   DATETIME,
+    timestamp_col  TIMESTAMP,
+    date_col       DATE,
+    time_col       TIME,
+    year_col       YEAR
+);
+
+-- Insert test data with comments
+INSERT INTO datatype_mapping_test_table (id, char_col, char_n_col, varchar_col,
+                                         tinytext_col, text_col, mediumtext_col,
+                                         tinyint_col, smallint_col, mediumint_col, int_col, bigint_col,
+                                         decimal_col, decimal_n_col, decimal_pq_col,
+                                         numeric_col, numeric_n_col, numeric_pq_col,
+                                         float_col, float_p_col, float_pq_col,
+                                         double_col, double_pq_col,
+                                         bit_col, bit_n_col,
+                                         binary_col, varbinary_col,
+                                         tinyblob_col, blob_col, mediumblob_col, longblob_col,
+                                         datetime_col, timestamp_col, date_col, time_col, year_col)
+VALUES (1, -- ID
+        'A', -- CHAR(1)
+        'ABCDEFGHIJ', -- CHAR(10)
+        'Hello MySQL', -- VARCHAR(100)
+        'Tiny text', -- TINYTEXT
+        'Normal text column', -- TEXT
+        'A much longer medium text value', -- MEDIUMTEXT
+
+        127, -- TINYINT
+        32767, -- SMALLINT
+        8388607, -- MEDIUMINT
+        2147483647, -- INT
+        9223372036854775807, -- BIGINT
+
+        12345.67, -- DECIMAL
+        1234567890, -- DECIMAL(10)
+        12345.67, -- DECIMAL(10,2)
+        98765.43, -- NUMERIC
+        54321, -- NUMERIC(10)
+        54321.98, -- NUMERIC(10,2)
+
+        1.23, -- FLOAT
+        12345.6789, -- FLOAT(10)
+        9876.54, -- FLOAT(10,2)
+        1234567.89, -- DOUBLE
+        1234567.89123, -- DOUBLE(15,5)
+
+        b'1', -- BIT
+        b'10101010', -- BIT(8)
+
+        UNHEX('00112233445566778899AABBCCDDEEFF'), -- BINARY(16)
+        UNHEX('A1B2C3'), -- VARBINARY(100)
+
+        'tinyblob', -- TINYBLOB
+        'this is a blob', -- BLOB
+        REPEAT('A', 1000), -- MEDIUMBLOB
+        REPEAT('B', 20000), -- LONGBLOB
+
+        '2025-09-04 15:30:45', -- DATETIME
+        CURRENT_TIMESTAMP, -- TIMESTAMP
+        '2025-09-04', -- DATE
+        '15:30:45', -- TIME
+        2025 -- YEAR
+       );

--- a/siard-cmd/src/integrationTest/resources/oracle/issues/siardsuite163/datatype-mapping-oracle.sql
+++ b/siard-cmd/src/integrationTest/resources/oracle/issues/siardsuite163/datatype-mapping-oracle.sql
@@ -1,0 +1,72 @@
+ALTER SESSION SET CONTAINER=XEPDB1;
+
+CREATE TABLE IT_USER.datatype_mapping_test
+(
+    id                     NUMBER PRIMARY KEY,
+    int_col                INTEGER, -- Numeric types
+    num_col                NUMBER,
+    num_prec_col           NUMBER(10),
+    num_prec_scale_col     NUMBER(10, 2),
+    smallint_col           SMALLINT,
+    decimal_col            DECIMAL,
+    decimal_prec_scale_col DECIMAL(10, 2),
+    numeric_col            NUMERIC,
+    numeric_prec_scale_col NUMERIC(10, 2),
+    float_col              FLOAT(10),
+    real_col               REAL,
+    double_prec_col        DOUBLE PRECISION,
+    binary_float_col       BINARY_FLOAT,
+    binary_double_col      BINARY_DOUBLE,
+    char_col               CHAR,    -- Character types
+    char_n_col             CHAR(10),
+    varchar_col            VARCHAR(100),
+    varchar2_col           VARCHAR2(100),
+    nchar_col              NCHAR,
+    nchar_n_col            NCHAR(10),
+    nvarchar2_col          NVARCHAR2(100),
+    clob_col               CLOB,    -- LOB types
+    nclob_col              NCLOB,
+    blob_col               BLOB,
+    raw_col                RAW(100),
+    longraw_col            LONG RAW,
+    date_col               DATE,    -- Date/Time types
+    timestamp_col          TIMESTAMP,
+    timestamp_n_col        TIMESTAMP(6),
+    timestamp_tz_col       TIMESTAMP WITH TIME ZONE,
+    timestamp_ltz_col      TIMESTAMP WITH LOCAL TIME ZONE
+);
+
+INSERT INTO IT_USER.datatype_mapping_test
+VALUES (1,
+        12345, -- INTEGER
+        9876543210.12345, -- NUMBER (no prec/scale)
+        9876543210, -- NUMBER(10)
+        1234.56, -- NUMBER(10,2)
+        123, -- SMALLINT
+        5678, -- DECIMAL (no prec/scale)
+        1234.56, -- DECIMAL(10,2)
+        9012, -- NUMERIC (no prec/scale)
+        1234.56, -- NUMERIC(10,2)
+        1.2345E+10, -- FLOAT(10)
+        1.2345, -- REAL
+        1.23456789012345E+100, -- DOUBLE PRECISION
+        1.2345E+10, -- BINARY_FLOAT
+        1.23456789012345E+100, -- BINARY_DOUBLE
+        'A', -- CHAR(1)
+        'TENCHARS', -- CHAR(10)
+        'VARCHAR test', -- VARCHAR(100)
+        'Variable length string up to 100 chars', -- VARCHAR2(100)
+        N'Ü', -- NCHAR(1)
+        N'ÜNICHAR10', -- NCHAR(10)
+        N'Unicode variable length string', -- NVARCHAR2(100)
+        'Character large object data', -- CLOB
+        N'Unicode CLOB data', -- NCLOB
+        HEXTORAW('1A2B3C4D5E6F'), -- BLOB
+        HEXTORAW('1A2B3C4D'), -- RAW(100)
+        HEXTORAW('1A2B3C4D5E6F'), -- LONG RAW
+        TO_DATE('2025-08-28', 'YYYY-MM-DD'), -- DATE
+        TO_TIMESTAMP('2025-08-28 15:30:45', 'YYYY-MM-DD HH24:MI:SS'), -- TIMESTAMP
+        SYSTIMESTAMP, -- TIMESTAMP(6)
+        TO_TIMESTAMP_TZ('2025-08-28 15:30:45 +02:00', 'YYYY-MM-DD HH24:MI:SS TZH:TZM'), -- TIMESTAMP WITH TIME ZONE
+        SYSTIMESTAMP -- TIMESTAMP WITH LOCAL TIME ZONE
+       );

--- a/siard-cmd/src/main/java/ch/admin/bar/siard2/cmd/MetaDataFromDb.java
+++ b/siard-cmd/src/main/java/ch/admin/bar/siard2/cmd/MetaDataFromDb.java
@@ -690,6 +690,7 @@ public class MetaDataFromDb extends MetaDataBase {
     private void getColumnData(ResultSet rs, MetaColumn mc) throws IOException, SQLException {
         int iDataType = rs.getInt("DATA_TYPE");
         String sTypeName = rs.getString("TYPE_NAME");
+        LOG.debug("JDBC Type: " + iDataType + " (" + getJdbcTypeName(iDataType) + "), DB Type: " + sTypeName);
         long lColumnSize = rs.getLong("COLUMN_SIZE");
         int iDecimalDigits = rs.getInt("DECIMAL_DIGITS");
         MetaSchema ms;
@@ -751,6 +752,19 @@ public class MetaDataFromDb extends MetaDataBase {
         }
         int iOrdinalPosition = rs.getInt("ORDINAL_POSITION");
         if (iOrdinalPosition != mc.getPosition()) throw new IOException("Invalid column position found!");
+    }
+
+    private String getJdbcTypeName(int type) {
+        try {
+            for (java.lang.reflect.Field field : java.sql.Types.class.getFields()) {
+                if ((Integer) field.get(null) == type) {
+                    return field.getName();
+                }
+            }
+        } catch (Exception e) {
+            return "UNKNOWN";
+        }
+        return "UNKNOWN";
     }
 
     /**

--- a/siard-cmd/src/main/java/ch/admin/bar/siard2/cmd/MetaDataFromDb.java
+++ b/siard-cmd/src/main/java/ch/admin/bar/siard2/cmd/MetaDataFromDb.java
@@ -690,9 +690,10 @@ public class MetaDataFromDb extends MetaDataBase {
     private void getColumnData(ResultSet rs, MetaColumn mc) throws IOException, SQLException {
         int iDataType = rs.getInt("DATA_TYPE");
         String sTypeName = rs.getString("TYPE_NAME");
-        LOG.debug("JDBC Type: " + iDataType + " (" + getJdbcTypeName(iDataType) + "), DB Type: " + sTypeName);
         long lColumnSize = rs.getLong("COLUMN_SIZE");
         int iDecimalDigits = rs.getInt("DECIMAL_DIGITS");
+        LOG.debug("JDBC Type: " + iDataType + " (" + getJdbcTypeName(iDataType) + "), Column Size: " + lColumnSize + ", Decimal Digits: " + iDecimalDigits);
+        LOG.debug("TypeOriginal: " + sTypeName);
         MetaSchema ms;
         QualifiedId qiParent;
         if (mc.getParentMetaTable() != null) {
@@ -711,6 +712,7 @@ public class MetaDataFromDb extends MetaDataBase {
             if (iDataType != Types.OTHER) mc.setPreType(iDataType, lColumnSize, iDecimalDigits);
             else mc.setType(sTypeName);
             mc.setTypeOriginal(sTypeName);
+            LOG.debug("SQL:1999 Type: " + mc.getType());
         } else if (iDataType == Types.ARRAY) {
             /* parse array constructor "<base> ARRAY[<n>]" */
             Matcher m = _patARRAY_CONSTRUCTOR.matcher(sTypeName);
@@ -756,15 +758,10 @@ public class MetaDataFromDb extends MetaDataBase {
 
     private String getJdbcTypeName(int type) {
         try {
-            for (java.lang.reflect.Field field : java.sql.Types.class.getFields()) {
-                if ((Integer) field.get(null) == type) {
-                    return field.getName();
-                }
-            }
-        } catch (Exception e) {
+            return java.sql.JDBCType.valueOf(type).getName();
+        } catch (IllegalArgumentException e) {
             return "UNKNOWN";
         }
-        return "UNKNOWN";
     }
 
     /**

--- a/siard-cmd/src/main/java/ch/admin/bar/siard2/cmd/MetaDataFromDb.java
+++ b/siard-cmd/src/main/java/ch/admin/bar/siard2/cmd/MetaDataFromDb.java
@@ -692,8 +692,6 @@ public class MetaDataFromDb extends MetaDataBase {
         String sTypeName = rs.getString("TYPE_NAME");
         long lColumnSize = rs.getLong("COLUMN_SIZE");
         int iDecimalDigits = rs.getInt("DECIMAL_DIGITS");
-        LOG.debug("JDBC Type: " + iDataType + " (" + getJdbcTypeName(iDataType) + "), Column Size: " + lColumnSize + ", Decimal Digits: " + iDecimalDigits);
-        LOG.debug("TypeOriginal: " + sTypeName);
         MetaSchema ms;
         QualifiedId qiParent;
         if (mc.getParentMetaTable() != null) {
@@ -712,7 +710,6 @@ public class MetaDataFromDb extends MetaDataBase {
             if (iDataType != Types.OTHER) mc.setPreType(iDataType, lColumnSize, iDecimalDigits);
             else mc.setType(sTypeName);
             mc.setTypeOriginal(sTypeName);
-            LOG.debug("SQL:1999 Type: " + mc.getType());
         } else if (iDataType == Types.ARRAY) {
             /* parse array constructor "<base> ARRAY[<n>]" */
             Matcher m = _patARRAY_CONSTRUCTOR.matcher(sTypeName);
@@ -754,14 +751,6 @@ public class MetaDataFromDb extends MetaDataBase {
         }
         int iOrdinalPosition = rs.getInt("ORDINAL_POSITION");
         if (iOrdinalPosition != mc.getPosition()) throw new IOException("Invalid column position found!");
-    }
-
-    private String getJdbcTypeName(int type) {
-        try {
-            return java.sql.JDBCType.valueOf(type).getName();
-        } catch (IllegalArgumentException e) {
-            return "UNKNOWN";
-        }
     }
 
     /**


### PR DESCRIPTION
Datatype mapping integration tests for Oracle and mySQL are from SiardCmd [ siardsuite-136/update-datatype-normalization-mapping](https://github.com/sfa-siard/SiardCmd/tree/siardsuite-136/update-datatype-normalization-mapping) branch. 

For the other datatype mapping tests I switched to `SoftAssertions`, to avoid the test exiting on first failure. SoftAssertions collects all failures across all assertions and reports them together at the end. When asserting many datatypes in one table, this is much more efficient. 